### PR TITLE
chore: Label Sync workflow を導入/更新

### DIFF
--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,4 +1,3 @@
-# GENERATED: scripts/sync-workflow-callers.sh により生成
 # ラベル同期（手動実行）
 #
 # 使用方法:
@@ -20,5 +19,5 @@ permissions:
 
 jobs:
   sync:
-    uses: ./.github/workflows/label-sync-wc.yml
+    uses: hasegawa496/.github/.github/workflows/label-sync-wc.yml@v1.0.0
     secrets: inherit


### PR DESCRIPTION
hasegawa496/.github の Reusable Workflow を呼び出して、ラベルを同期できるようにします。