### PR TITLE
feat: Dependabot自動マージ用Reusable Workflowを追加する

### DIFF
--- a/.github/workflows/dependabot-automerge-wc.yml
+++ b/.github/workflows/dependabot-automerge-wc.yml
@@ -1,0 +1,51 @@
+# Dependabot 自動マージ Reusable Workflow
+#
+# 対象:
+#   - github-actions の patch / minor 更新
+#   - セキュリティ更新 PR (automated_security_fixes 経由)
+#   - npm / pip などのパッケージマネージャーの patch 更新
+#
+# 使用方法:
+#   各リポジトリの .github/workflows/dependabot-automerge.yml から呼び出す
+#   例: hasegawa496/my-life の .github/workflows/dependabot-automerge.yml を参照
+
+name: Dependabot Auto-merge (Reusable)
+
+on:
+  workflow_call:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Auto-merge github-actions patch/minor updates
+        if: |
+          steps.metadata.outputs.package-ecosystem == 'github_actions' &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+           steps.metadata.outputs.update-type == 'version-update:semver-minor')
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge package manager patch updates (direct dependencies)
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' &&
+          (steps.metadata.outputs.dependency-type == 'direct:production' ||
+           steps.metadata.outputs.dependency-type == 'direct:development') &&
+          contains(fromJSON('["npm", "pip", "cargo", "composer", "nuget", "bundler", "gomod"]'), steps.metadata.outputs.package-ecosystem)
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 概要

Dependabot PR を自動マージする Reusable Workflow を追加する。  
各リポジトリの Caller から `uses: hasegawa496/.github/.github/workflows/dependabot-automerge-wc.yml@main` で呼び出す。

## 変更内容

### `.github/workflows/dependabot-automerge-wc.yml` (新規)

`dependabot/fetch-metadata@v2` で PR のメタ情報を取得し、条件に応じて `gh pr merge --auto --squash` を実行する。

| ステップ | 条件 |
|---------|------|
| github-actions patch/minor | `ecosystem == github_actions` AND `update-type == patch OR minor` |
| package manager patch | `ecosystem IN [npm,pip,cargo,...]` AND `update-type == patch` AND `dep-type == direct:*` |

- major 更新は対象外（手動レビュー）
- indirect dependencies は対象外

## 利用方法

各リポジトリに以下を配置する（`hasegawa496/my-life` は PR #72 で追加済み）:

```yaml
name: Dependabot Auto-merge
on:
  pull_request:
permissions:
  contents: write
  pull-requests: write
jobs:
  automerge:
    uses: hasegawa496/.github/.github/workflows/dependabot-automerge-wc.yml@main
    secrets: inherit
```

## 事前条件

自動マージを有効にするリポジトリで「Allow auto-merge」を Settings から有効化すること。