### PR TITLE
feat: patrol-deferred ラベルを標準定義に追加する

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -30,11 +30,15 @@
 # patrol ラベル（Issue巡回フロー用）
 - name: needs-design
   color: "e4e669"
-  description: "仕様詰めが必要。AIが設計を掘り下げ、人間レビュー待ちに移行する"
+  description: "仕様不足、または調査・比較に少し時間がかかる。AIが後続で設計を深掘りする"
 
 - name: needs-review
   color: "fbca04"
-  description: "AI処理済み。人間レビュー待ち。ラベルを外すと通常実装フローへ"
+  description: "人間の最終判断待ち。実装前に論点整理済みの Issue をレビューキューとして保持する"
+
+- name: patrol-deferred
+  color: "bfd4f2"
+  description: "依存先の open Issue などがあり、patrol では今は後回しにする"
 
 # status ラベル
 - name: duplicate


### PR DESCRIPTION
## 概要
- patrol 用の標準ラベルに patrol-deferred を追加する
- needs-design / needs-review の説明を現在の運用に合わせて更新する
- repo-ops の巡回スキップ運用で使う標準ラベルを配布可能にする

## テスト
- [ ] ラベル定義変更のみのため未実施