### PR TITLE
fix: dependabot自動マージをCI成功による無条件マージに変更する

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -30,11 +30,15 @@
 # patrol ラベル（Issue巡回フロー用）
 - name: needs-design
   color: "e4e669"
-  description: "仕様詰めが必要。AIが設計を掘り下げ、人間レビュー待ちに移行する"
+  description: "仕様不足、または調査・比較に少し時間がかかる。AIが後続で設計を深掘りする"
 
 - name: needs-review
   color: "fbca04"
-  description: "AI処理済み。人間レビュー待ち。ラベルを外すと通常実装フローへ"
+  description: "人間の最終判断待ち。実装前に論点整理済みの Issue をレビューキューとして保持する"
+
+- name: patrol-deferred
+  color: "bfd4f2"
+  description: "依存先の open Issue などがあり、patrol では今は後回しにする"
 
 # status ラベル
 - name: duplicate

--- a/.github/workflows/dependabot-automerge-wc.yml
+++ b/.github/workflows/dependabot-automerge-wc.yml
@@ -35,10 +35,13 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: ${{ github.repository }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           pr_number=$(gh pr list --repo "$REPO" --head "$HEAD_BRANCH" --json number --jq '.[0].number')
           if [ -z "$pr_number" ]; then
             echo "対象PRが見つかりませんでした: $HEAD_BRANCH"
             exit 0
           fi
-          gh pr merge "$pr_number" --repo "$REPO" --squash
+          # CIが成功した head_sha と現在のPR headが一致する場合のみマージする（
+          # dependabotがCI成功後にrebase/更新pushした場合の未検証コミット混入を防ぐ）
+          gh pr merge "$pr_number" --repo "$REPO" --squash --match-head-commit "$HEAD_SHA"

--- a/.github/workflows/dependabot-automerge-wc.yml
+++ b/.github/workflows/dependabot-automerge-wc.yml
@@ -1,13 +1,18 @@
 # Dependabot 自動マージ Reusable Workflow
 #
 # 対象:
-#   - github-actions の patch / minor 更新
-#   - セキュリティ更新 PR (automated_security_fixes 経由)
-#   - npm / pip などのパッケージマネージャーの patch 更新
+#   - dependabot が作成した PR に紐づく CI ワークフローが成功した場合、
+#     patch / minor / major の区別なく無条件でマージする
+#   - 呼び出し元 repo は on.workflow_run.workflows に監視対象の CI workflow 名を指定する
 #
 # 使用方法:
 #   各リポジトリの .github/workflows/dependabot-automerge.yml から呼び出す
 #   例: hasegawa496/my-life の .github/workflows/dependabot-automerge.yml を参照
+#
+# 注意:
+#   required_status_checks（branch protection）は private repo で有料プラン必須のため
+#   未導入（ADR-001）。そのため GitHub 標準の auto-merge には頼らず、CI 完了
+#   （workflow_run）を明示的にトリガーとして拾い、conclusion を確認してから即時マージする。
 
 name: Dependabot Auto-merge (Reusable)
 
@@ -21,38 +26,19 @@ permissions:
 jobs:
   automerge:
     runs-on: ubuntu-latest
-    if: github.actor == 'dependabot[bot]'
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.actor.login == 'dependabot[bot]'
     steps:
-      - name: Fetch Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v3
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
-      - name: Auto-merge github-actions patch/minor updates
-        if: |
-          steps.metadata.outputs.package-ecosystem == 'github_actions' &&
-          (steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-           steps.metadata.outputs.update-type == 'version-update:semver-minor')
-        run: gh pr merge --auto --squash "$PR_URL"
+      - name: dependabot PR をマージする
         env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Auto-merge package manager patch updates (direct dependencies)
-        if: |
-          steps.metadata.outputs.update-type == 'version-update:semver-patch' &&
-          (steps.metadata.outputs.dependency-type == 'direct:production' ||
-           steps.metadata.outputs.dependency-type == 'direct:development') &&
-          contains(fromJSON('["npm", "pip", "cargo", "composer", "nuget", "bundler", "gomod"]'), steps.metadata.outputs.package-ecosystem)
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Auto-merge security updates (GHSA/CVE)
-        if: steps.metadata.outputs.ghsa-ids != ''
-        run: gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          pr_number=$(gh pr list --repo "$REPO" --head "$HEAD_BRANCH" --json number --jq '.[0].number')
+          if [ -z "$pr_number" ]; then
+            echo "対象PRが見つかりませんでした: $HEAD_BRANCH"
+            exit 0
+          fi
+          gh pr merge "$pr_number" --repo "$REPO" --squash


### PR DESCRIPTION
## 概要
- `dependabot-automerge-wc.yml`（Reusable Workflow）を `workflow_run`（CI完了）トリガー・conclusion確認ベースの即時マージ方式に変更
- `dependabot/fetch-metadata` によるpatch/minor判定を撤廃し、CI success であれば無条件でマージする
- 呼び出し元repoは `on.workflow_run.workflows` に監視対象のCI workflow名を指定する運用に変更（misa-playerで先行反映: hasegawa496/misa-player の同名PR参照）

## 背景
private repo では `required_status_checks`（branch protection）が有料プラン必須で導入不可（ADR-001, hasegawa496/repo-ops）。そのため `gh pr merge --auto` はCI完了を待つ保証を提供しない。CI完了イベントを明示的にトリガーにし、conclusionを確認してからマージする方式に切り替える。

関連: hasegawa496/repo-ops#18

## テスト
- [x] YAML構文チェック（`yaml.safe_load`）
- [ ] 実際のdependabot PRでの動作確認は未実施（マージ後、次回dependabot PR発生時に確認）