### PR TITLE
fix: triage workflowのフォールバックコメントで改行がリテラル文字列になる不具合を修正する

### DIFF
--- a/.github/workflows/triage-wc.yml
+++ b/.github/workflows/triage-wc.yml
@@ -67,6 +67,7 @@ jobs:
 
           comment() {
             local body="$1"
+            body="${body//\\n/$'\n'}"
             GH_TOKEN="${GITHUB_TOKEN}" gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/comments" -f body="$body" >/dev/null || true
           }
 


### PR DESCRIPTION
## 概要
- `triage-wc.yml` の `comment()` 関数へ渡す本文文字列内の `\n\n` が、bashのダブルクォート文字列では改行として解釈されず、`gh api` にリテラルな `\n` の2文字のまま渡っていた
- 結果としてフォールバックコメントが改行なしの1行でGitHub上に表示されていた
- `comment()` 内で `\n` を実改行へ変換するよう修正した

## 発見経緯
Issue #23（awk予約語衝突の修正）対応の実Issue検証中（Issue #25）に発見。ハード失敗はしないため Issue #23 の要求自体は満たしていたが、コメントの可読性が損なわれていた。

## テスト
- [x] `bash -n` でシェル構文チェック
- [x] 修正後の `comment()` ロジックをローカルで単体実行し、改行が正しく反映されることを確認
- [x] `shellcheck` で既存差分箇所に新規の警告がないことを確認