### PR TITLE
docs: Issueトリアージ導入手順にPROJECT_TOKEN設定要件を追記する

### DIFF
--- a/docs/github-workflow-operations.md
+++ b/docs/github-workflow-operations.md
@@ -31,6 +31,9 @@
 
 - `workflow-templates/triage.yml` を配布先の `.github/workflows/triage.yml` として配置
 - スクリプト導入する場合は `scripts/setup-triage-project-fields.sh` を配布先ルートで実行
+- 前提として、配布先repoに Projects v2 書き込み権限を持つ `PROJECT_TOKEN` secret が設定済みであること
+  - `PROJECT_TOKEN` の発行・全repoへの一括配布は `hasegawa496/repo-ops` 側で一元管理する（`scripts/setup-project-token-secrets.sh` を参照）
+  - 未設定のまま workflow を導入すると、Issue作成/編集時のトリアージ実行が失敗する
 
 ## 運用ルール（配置・命名）
 


### PR DESCRIPTION
## 概要

Issueトリアージ workflow導入チェックリストに、`PROJECT_TOKEN` secretが前提であることを明記する。

## 背景

triage workflowはProjects v2書き込みに`PROJECT_TOKEN` secretを必要とするが、導入手順にその前提が明記されておらず、secret未設定のままworkflowだけ導入するとトリアージ実行が失敗する。`PROJECT_TOKEN`の発行・全repoへの一括配布は`hasegawa496/repo-ops`側で一元管理する（関連PR: hasegawa496/repo-ops#37）。

## Test plan

- [x] ドキュメントのみの変更（Markdown追記）