### PR TITLE
feat: Dependabot自動マージの配布テンプレートと導入スクリプトを追加する

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,28 @@
+# GENERATED: scripts/sync-workflow-callers.sh により生成
+# Dependabot 自動マージ（配布先へコピーして使う workflow）
+#
+# 使い方:
+#   1) このファイルを各リポジトリの `.github/workflows/dependabot-automerge.yml` へコピーして push
+#      （自動導入する場合は `scripts/setup-dependabot-automerge.sh` を配布先ルートで実行）
+#   2) `workflows:` に、そのリポジトリの CI workflow の `name:`（見出しの workflow 名）を指定する
+#      - CI workflow を持たないリポジトリでは、このファイルを導入しても発火しない（安全側の挙動）
+#
+# 対象:
+#   - dependabot が作成した PR に紐づく CI workflow が成功した場合、
+#     patch / minor / major の区別なく無条件でマージする
+
+name: Dependabot Auto-merge
+
+on:
+  workflow_run:
+    workflows: ["ShellCheck"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    uses: ./.github/workflows/dependabot-automerge-wc.yml
+    secrets: inherit

--- a/.github/workflows/label-sync.yml
+++ b/.github/workflows/label-sync.yml
@@ -1,3 +1,4 @@
+# GENERATED: scripts/sync-workflow-callers.sh により生成
 # ラベル同期（手動実行）
 #
 # 使用方法:
@@ -19,5 +20,5 @@ permissions:
 
 jobs:
   sync:
-    uses: hasegawa496/.github/.github/workflows/label-sync-wc.yml@v1
+    uses: ./.github/workflows/label-sync-wc.yml
     secrets: inherit

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   - `.github/workflows/label-sync-wc.yml`
   - `.github/workflows/shellcheck-wc.yml`
   - `.github/workflows/triage-wc.yml`
+  - `.github/workflows/dependabot-automerge-wc.yml`
 - 配布テンプレート
   - `workflow-templates/*.yml`
 - 導入/同期スクリプト

--- a/docs/github-workflow-operations.md
+++ b/docs/github-workflow-operations.md
@@ -32,6 +32,13 @@
 - `workflow-templates/triage.yml` を配布先の `.github/workflows/triage.yml` として配置
 - スクリプト導入する場合は `scripts/setup-triage-project-fields.sh` を配布先ルートで実行
 
+### 5) Dependabot 自動マージ
+
+- `workflow-templates/dependabot-automerge.yml` を配布先の `.github/workflows/dependabot-automerge.yml` として配置し、`on.workflow_run.workflows` に配布先の CI workflow 名を指定する
+- 自動導入する場合は `CI_WORKFLOW_NAME=<CI workflow の name>` を指定して `scripts/setup-dependabot-automerge.sh` を配布先ルートで実行（未指定時は既定値 `CI`）
+- CI workflow を持たない配布先には導入しても発火しない（安全側の挙動）。配布先ごとの導入要否・CI workflow 名の棚卸しは `hasegawa496/repo-ops` の `docs/dependabot-operations.md` 側で管理する
+- 導入 PR はスクリプトが作成後に自動マージする
+
 ## 運用ルール（配置・命名）
 
 - `.github/workflows/*.yml`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -9,6 +9,7 @@
 - `setup-dependabot.sh`: Dependabot 設定を導入/更新し、PR を自動マージ（引数なし）
 - `setup-label-sync.sh`: ラベル同期 workflow を導入/更新し、起動（引数なし）
 - `setup-triage-project-fields.sh`: Issue トリアージ workflow を導入/更新（引数なし）
+- `setup-dependabot-automerge.sh`: Dependabot 自動マージ workflow を導入/更新し、PR を自動マージ（引数なし、`CI_WORKFLOW_NAME` 環境変数で監視対象の CI workflow 名を指定。既定値 `CI`）
 - `sync-workflow-callers.sh`: `workflow-templates/` を元に `.github/workflows/` の呼び出し側 workflow を同期
 - `check-workflow-templates.sh`: `workflow-templates/` の簡易検証（ローカル参照の混在チェック、`@v1` の有無など）
 - `lib/common.sh`: 共通関数（`cd_repo_root`, `ensure_gh_auth`, `ensure_actions_enabled` など）

--- a/scripts/setup-dependabot-automerge.sh
+++ b/scripts/setup-dependabot-automerge.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# 配布先リポジトリに Dependabot 自動マージ workflow を導入/更新する。
+# workflow-templates/dependabot-automerge.yml をコピーし、その配布先の CI workflow 名
+# （on.workflow_run.workflows）を CI_WORKFLOW_NAME 環境変数で差し替えてから導入する。
+# CI workflow を持たない配布先には導入しても発火しないため、呼び出し側で導入要否を判断すること。
+set -euo pipefail
+
+# shellcheck disable=SC1007
+script_dir="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/common.sh
+source "$script_dir/lib/common.sh"
+
+assert_no_args "$@"
+cd_repo_root
+ensure_gh_auth
+
+repo_full="$(get_repo_full)"
+ci_workflow_name="${CI_WORKFLOW_NAME:-CI}"
+
+default_branch="$(gh repo view --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || true)"
+default_branch="${default_branch:-main}"
+
+template_workflow="$script_dir/../workflow-templates/dependabot-automerge.yml"
+if [[ ! -f "$template_workflow" ]]; then
+  die "テンプレートが見つかりません: $template_workflow"
+fi
+
+expected_workflow="$(mktemp -t dependabot-automerge.XXXXXX)"
+cleanup() { rm -f "$expected_workflow"; }
+trap cleanup EXIT
+
+cp "$template_workflow" "$expected_workflow"
+sed -i -e "s#workflows: \\[\"CI\"\\]#workflows: [\"${ci_workflow_name}\"]#" "$expected_workflow"
+
+ensure_actions_enabled "$repo_full"
+
+workflow_path=".github/workflows/dependabot-automerge.yml"
+needs_apply_template="true"
+
+if [[ -f "$workflow_path" ]]; then
+  if ! command -v cmp >/dev/null 2>&1; then
+    echo "既に存在します: $workflow_path（cmp が無いため、テンプレートで更新して導入を続行します）。" >&2
+  elif cmp -s "$workflow_path" "$expected_workflow"; then
+    needs_apply_template="false"
+    echo "既に存在します: $workflow_path（同一内容のため、更新不要です）" >&2
+  fi
+fi
+
+if [[ "$needs_apply_template" == "false" ]]; then
+  exit 0
+fi
+
+ensure_clean_worktree
+ensure_origin_exists
+
+base_ref="$(ensure_remote_base_ref "$default_branch")"
+
+ts="$(date -u +%Y%m%d-%H%M%S)"
+branch="chore/update-dependabot-automerge-$ts"
+
+if git show-ref --verify --quiet "refs/heads/$branch"; then
+  die "ローカルに同名ブランチが存在します: $branch（時間をおいて再実行してください）"
+fi
+
+if ! err="$(git checkout -q -b "$branch" "$base_ref" 2>&1)"; then
+  echo "$err" >&2
+  die "ブランチの作成に失敗しました。"
+fi
+
+mkdir -p "$(dirname "$workflow_path")"
+cp "$expected_workflow" "$workflow_path"
+
+git add "$workflow_path"
+if ! err="$(git commit -q -m "chore: Dependabot 自動マージ workflow を導入/更新" 2>&1)"; then
+  echo "$err" >&2
+  die "コミットに失敗しました。"
+fi
+
+if ! err="$(git push --quiet -u origin "$branch" 2>&1)"; then
+  echo "$err" >&2
+  die "push に失敗しました。リモート/権限/ブランチ保護などを確認してください。"
+fi
+
+if ! pr_number="$(create_or_get_pr \
+  "$default_branch" \
+  "$branch" \
+  "chore: Dependabot 自動マージ workflow を導入/更新" \
+  "hasegawa496/.github の Reusable Workflow を呼び出して、CI（\`${ci_workflow_name}\`）成功時に dependabot PR を自動マージできるようにします。")"; then
+  exit 1
+fi
+
+echo "PR をマージします..." >&2
+if ! merge_pr_or_fail \
+  "$pr_number" \
+  "$branch" \
+  "PR を自動でマージできませんでした。PR を手動でマージしてください。"; then
+  exit 1
+fi
+
+echo "導入完了: Dependabot 自動マージ" >&2
+
+if ! git show-ref --verify --quiet "refs/heads/$default_branch"; then
+  git fetch --quiet origin "$default_branch" >/dev/null 2>&1 || true
+  git checkout -q -B "$default_branch" "origin/$default_branch"
+else
+  git checkout -q "$default_branch"
+  git pull --ff-only --quiet origin "$default_branch" >/dev/null 2>&1 || true
+fi
+
+if git show-ref --verify --quiet "refs/heads/$branch"; then
+  git branch -D "$branch" >/dev/null 2>&1 || true
+fi
+
+git push --quiet origin --delete "$branch" >/dev/null 2>&1 || true

--- a/scripts/sync-workflow-callers.sh
+++ b/scripts/sync-workflow-callers.sh
@@ -36,6 +36,7 @@ render() {
   local dst="$2"
   local local_uses="$3"
   local name_override="${4:-}"
+  local workflows_override="${5:-}"
 
   [[ -f "$src" ]] || die "見つかりません: $src"
 
@@ -48,11 +49,15 @@ render() {
   #   uses: hasegawa496/.github/.github/workflows/shellcheck-wc.yml@v1
   #   uses: ./.github/workflows/shellcheck-wc.yml
   sed -i \
-    -e "s#uses: \\s*hasegawa496/.github/\\.github/workflows/[^[:space:]]\\+@v1#uses: ${local_uses}#g" \
+    -e "s#uses:[[:space:]]*hasegawa496/\\.github/\\.github/workflows/[^[:space:]@]\\+\\.yml@[^[:space:]]\\+#uses: ${local_uses}#g" \
     "$out"
 
   if [[ -n "${name_override:-}" ]]; then
     sed -i -e "s#^name: .*#name: ${name_override}#g" "$out"
+  fi
+
+  if [[ -n "${workflows_override:-}" ]]; then
+    sed -i -e "s#workflows: \\[\"CI\"\\]#workflows: [\"${workflows_override}\"]#" "$out"
   fi
 
   # 生成物であることを明示（先頭に短い注記を挿入）
@@ -79,5 +84,6 @@ render() {
 render "workflow-templates/shellcheck.yml" ".github/workflows/shellcheck.yml" "./.github/workflows/shellcheck-wc.yml"
 render "workflow-templates/label-sync.yml" ".github/workflows/label-sync.yml" "./.github/workflows/label-sync-wc.yml"
 render "workflow-templates/triage.yml" ".github/workflows/triage.yml" "./.github/workflows/triage-wc.yml"
+render "workflow-templates/dependabot-automerge.yml" ".github/workflows/dependabot-automerge.yml" "./.github/workflows/dependabot-automerge-wc.yml" "" "ShellCheck"
 
 echo "OK: 呼び出し側 workflow を同期しました（$mode）"

--- a/workflow-templates/dependabot-automerge.yml
+++ b/workflow-templates/dependabot-automerge.yml
@@ -1,0 +1,27 @@
+# Dependabot 自動マージ（配布先へコピーして使う workflow）
+#
+# 使い方:
+#   1) このファイルを各リポジトリの `.github/workflows/dependabot-automerge.yml` へコピーして push
+#      （自動導入する場合は `scripts/setup-dependabot-automerge.sh` を配布先ルートで実行）
+#   2) `workflows:` に、そのリポジトリの CI workflow の `name:`（見出しの workflow 名）を指定する
+#      - CI workflow を持たないリポジトリでは、このファイルを導入しても発火しない（安全側の挙動）
+#
+# 対象:
+#   - dependabot が作成した PR に紐づく CI workflow が成功した場合、
+#     patch / minor / major の区別なく無条件でマージする
+
+name: Dependabot Auto-merge
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    uses: hasegawa496/.github/.github/workflows/dependabot-automerge-wc.yml@main
+    secrets: inherit


### PR DESCRIPTION
## 概要

- 全リポジトリへ Dependabot 自動マージを展開できるようにするための配布テンプレートと導入スクリプトを追加する
  - `workflow-templates/dependabot-automerge.yml`: 配布先へコピーして使う caller workflow のテンプレート
  - `scripts/setup-dependabot-automerge.sh`: 配布先リポジトリへ導入し、PRを自動マージするスクリプト（`CI_WORKFLOW_NAME` 環境変数で監視対象のCI workflow名を指定、既定値 `CI`）
- このリポジトリ自身にも `sync-workflow-callers.sh` 経由で `.github/workflows/dependabot-automerge.yml` を導入する（監視対象は本リポジトリのCIである `ShellCheck`）
- `docs/github-workflow-operations.md` / `README.md` / `scripts/README.md` に導入手順を追記する

## ついでに修正した既存の不具合

- `sync-workflow-callers.sh` の `local_uses` 置換が `@v1` 固定の正規表現だったため、`@main` など別refの参照を持つテンプレートに対応できなかった。正規表現を一般化した
- 上記の一般化により、`.github/workflows/label-sync.yml` が本来ローカル参照 (`./.github/workflows/label-sync-wc.yml`) であるべきところ、cross-repo参照 (`hasegawa496/.github/.github/workflows/label-sync-wc.yml@v1`) に紛れ込んでいたドリフトを検出・修正した（`scripts/check-workflow-templates.sh` が今後このドリフトを検出できる）

## 後続作業（別PR予定）

- `hasegawa496/repo-ops` 側に、全管理対象リポジトリへ本スクリプトを適用するロールアウトスクリプトを追加する
- `hasegawa496/my-life` は現在 `dependabot-automerge.yml` が `on: pull_request` のままで、現行の `dependabot-automerge-wc.yml`（workflow_run前提）と噛み合っておらず自動マージが発火しない状態。ロールアウトスクリプトで修正する

## テスト

- [x] `bash -n scripts/setup-dependabot-automerge.sh` / `bash -n scripts/sync-workflow-callers.sh`
- [x] `shellcheck` （pre-commit hookで実行）
- [x] `scripts/check-workflow-templates.sh`
- [x] `scripts/sync-workflow-callers.sh --write` の結果を確認