### PR TITLE
feat: Dependabot自動マージを標準セットアップに組み込む

### DIFF
--- a/docs/github-workflow-operations.md
+++ b/docs/github-workflow-operations.md
@@ -38,7 +38,8 @@
 ### 5) Dependabot 自動マージ
 
 - `workflow-templates/dependabot-automerge.yml` を配布先の `.github/workflows/dependabot-automerge.yml` として配置し、`on.workflow_run.workflows` に配布先の CI workflow 名を指定する
-- 自動導入する場合は `CI_WORKFLOW_NAME=<CI workflow の name>` を指定して `scripts/setup-dependabot-automerge.sh` を配布先ルートで実行（未指定時は既定値 `CI`）
+- `scripts/setup.sh`（`hasegawa496/repo-ops` の `scripts/repos apply`/`init`/`create` から呼ばれる）に組み込み済みで、既定値 `CI` で導入される
+- CI workflow 名が `CI` と異なる配布先は、`CI_WORKFLOW_NAME=<CI workflow の name>` を指定して `scripts/setup-dependabot-automerge.sh` を配布先ルートで個別実行する
 - CI workflow を持たない配布先には導入しても発火しない（安全側の挙動）。配布先ごとの導入要否・CI workflow 名の棚卸しは `hasegawa496/repo-ops` の `docs/dependabot-operations.md` 側で管理する
 - 導入 PR はスクリプトが作成後に自動マージする
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,7 +4,7 @@
 
 ## 一覧
 
-- `setup.sh`: 標準構成のまとめ実行（設定 → Dependabot → ラベル同期、引数なし）
+- `setup.sh`: 標準構成のまとめ実行（設定 → Dependabot → ラベル同期 → Dependabot自動マージ、引数なし。`hasegawa496/repo-ops` の `scripts/repos apply`/`init`/`create` から呼ばれる）
 - `setup-repo-settings.sh`: リポジトリ設定の初期化（ブランチ自動削除など、引数なし）
 - `setup-dependabot.sh`: Dependabot 設定を導入/更新し、PR を自動マージ（引数なし）
 - `setup-label-sync.sh`: ラベル同期 workflow を導入/更新し、起動（引数なし）

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -11,6 +11,7 @@ assert_no_args "$@"
 "$script_dir/setup-repo-settings.sh"
 "$script_dir/setup-dependabot.sh"
 "$script_dir/setup-label-sync.sh"
+"$script_dir/setup-dependabot-automerge.sh"
 
 # git hooks を有効化する（コミット前に shellcheck を自動実行）
 git config core.hooksPath .githooks


### PR DESCRIPTION
## 概要

- #29 で追加した `setup-dependabot-automerge.sh` を `scripts/setup.sh` に組み込む
- これにより `hasegawa496/repo-ops` の `scripts/repos apply`（既存repo）/ `init` / `create`（新規repo）が、新規・既存を問わず同じ経路で Dependabot 自動マージを導入できるようになる
- CI workflow 名は既定値 `CI` とする。異なる配布先は `CI_WORKFLOW_NAME=<name>` を指定して `scripts/setup-dependabot-automerge.sh` を個別実行する運用

## 注意（既知の制約、対応不要）

- `scripts/repos apply` を対象未指定で実行すると `hasegawa496/.github` 自身にも `setup.sh` が走り、`dependabot-automerge.yml`（本来はローカル参照 `./...`）が配布先向けテンプレ（cross-repo参照）で上書きされる。これは既存の `label-sync.yml` 等でも同じ構造の既知の副作用のため、`.github` 自身は `scripts/repos apply` の対象から個別に外して運用する

## テスト

- [x] `bash -n scripts/setup.sh`
- [x] `shellcheck`（pre-commit hookで実行）
- [x] `scripts/check-workflow-templates.sh`