### PR TITLE
fix: setup-*.shがhasegawa496/.github自身に呼び出し側workflowを配布しないようにする

### DIFF
--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -42,6 +42,16 @@ ensure_gh_auth() {
   fi
 }
 
+SELF_MANAGED_CALLER_REPO="hasegawa496/.github"
+
+# hasegawa496/.github 自身の呼び出し側 workflow（label-sync.yml 等）は、
+# 配布用テンプレート（cross-repo参照）ではなく scripts/sync-workflow-callers.sh が
+# ローカル参照版を自己管理している。caller workflow を配布する setup-*.sh は、
+# 対象がこの repo 自身のときだけこの関数で早期スキップする。
+is_self_managed_caller_repo() {
+  [[ "$1" == "$SELF_MANAGED_CALLER_REPO" ]]
+}
+
 get_repo_full() {
   local repo_full
   repo_full="$(gh repo view --json nameWithOwner -q '.nameWithOwner' 2>/dev/null || true)"

--- a/scripts/setup-dependabot-automerge.sh
+++ b/scripts/setup-dependabot-automerge.sh
@@ -15,6 +15,12 @@ cd_repo_root
 ensure_gh_auth
 
 repo_full="$(get_repo_full)"
+
+if is_self_managed_caller_repo "$repo_full"; then
+  echo "${repo_full} は呼び出し側 workflow を scripts/sync-workflow-callers.sh で自己管理するため、導入をスキップします。" >&2
+  exit 0
+fi
+
 ci_workflow_name="${CI_WORKFLOW_NAME:-CI}"
 
 default_branch="$(gh repo view --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || true)"

--- a/scripts/setup-label-sync.sh
+++ b/scripts/setup-label-sync.sh
@@ -71,13 +71,14 @@ ensure_gh_auth
 
 repo_full="$(get_repo_full)"
 
-if is_self_managed_caller_repo "$repo_full"; then
-  echo "${repo_full} は呼び出し側 workflow を scripts/sync-workflow-callers.sh で自己管理するため、導入をスキップします。" >&2
-  exit 0
-fi
-
 default_branch="$(gh repo view --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || true)"
 default_branch="${default_branch:-main}"
+
+if is_self_managed_caller_repo "$repo_full"; then
+  echo "${repo_full} は呼び出し側 workflow を scripts/sync-workflow-callers.sh で自己管理するため、テンプレート導入はスキップし、起動のみ行います。" >&2
+  run_label_sync_workflow "$default_branch"
+  exit $?
+fi
 
 # このスクリプト自身（my-life）のテンプレートを正本として利用する。
 # 想定実行: my-life を clone した状態で、対象リポジトリ上から相対/絶対パスで本スクリプトを呼ぶ。

--- a/scripts/setup-label-sync.sh
+++ b/scripts/setup-label-sync.sh
@@ -71,6 +71,11 @@ ensure_gh_auth
 
 repo_full="$(get_repo_full)"
 
+if is_self_managed_caller_repo "$repo_full"; then
+  echo "${repo_full} は呼び出し側 workflow を scripts/sync-workflow-callers.sh で自己管理するため、導入をスキップします。" >&2
+  exit 0
+fi
+
 default_branch="$(gh repo view --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || true)"
 default_branch="${default_branch:-main}"
 


### PR DESCRIPTION
## 背景

PR #29/#30 のレビュー中、「`scripts/repos apply` を `hasegawa496/.github` 自身も含めて無指定で実行すると、自己参照（`./...`）で管理している呼び出し側 workflow（`label-sync.yml`/`dependabot-automerge.yml`）が配布用テンプレート（cross-repo参照）で上書きされる」という既知の副作用を指摘した。

これに対し、「`.github` を `apply` の対象からまるごと除外する」のは粒度が粗すぎる（repo設定・Dependabot設定など、`.github` 自身にも適用すべき項目まで止まってしまう）と気づいたため、対症療法ではなく `setup-label-sync.sh` / `setup-dependabot-automerge.sh` 側に自己スキップを実装した。

## 変更内容

- `scripts/lib/common.sh` に `is_self_managed_caller_repo` を追加
- `setup-label-sync.sh` / `setup-dependabot-automerge.sh` は、対象が `hasegawa496/.github` 自身のときは早期スキップする
- これにより `scripts/repos apply` を `hasegawa496/.github` を除外せず全repo一律で実行できる

## テスト

- [x] `bash -n` / `shellcheck`（pre-commit hookで実行）
- [x] `scripts/check-workflow-templates.sh`
- [x] `.github` 自身のclone内で両スクリプトを実行し、スキップメッセージと exit 0 を確認