### PR TITLE
refactor: caller workflow配布の共通処理をinstall_or_skip_caller_workflowに集約し、Issueトリアージもsetup.shへ統合する

### DIFF
--- a/docs/github-workflow-operations.md
+++ b/docs/github-workflow-operations.md
@@ -15,6 +15,7 @@
 自動導入する場合:
 
 - `scripts/setup-label-sync.sh` を配布先リポジトリのルートで実行
+- `scripts/setup.sh`（`hasegawa496/repo-ops` の `scripts/repos apply`/`init`/`create` から呼ばれる）に組み込み済み
 
 ### 2) Dependabot
 
@@ -31,9 +32,10 @@
 
 - `workflow-templates/triage.yml` を配布先の `.github/workflows/triage.yml` として配置
 - スクリプト導入する場合は `scripts/setup-triage-project-fields.sh` を配布先ルートで実行
+- `scripts/setup.sh`（`hasegawa496/repo-ops` の `scripts/repos apply`/`init`/`create` から呼ばれる）に組み込み済み
 - 前提として、配布先repoに Projects v2 書き込み権限を持つ `PROJECT_TOKEN` secret が設定済みであること
   - `PROJECT_TOKEN` の発行・全repoへの一括配布は `hasegawa496/repo-ops` 側で一元管理する（`scripts/setup-project-token-secrets.sh` を参照）
-  - 未設定のまま workflow を導入すると、Issue作成/編集時のトリアージ実行が失敗する
+  - 未設定のまま workflow を導入しても導入自体は失敗しない。Issue作成/編集時のトリアージ実行時にフォールバックコメントが付くだけで、`PROJECT_TOKEN` を後から設定すれば動くようになる
 
 ### 5) Dependabot 自動マージ
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,12 +4,13 @@
 
 ## 一覧
 
-- `setup.sh`: 標準構成のまとめ実行（設定 → Dependabot → ラベル同期 → Dependabot自動マージ、引数なし。`hasegawa496/repo-ops` の `scripts/repos apply`/`init`/`create` から呼ばれる）
+- `setup.sh`: 標準構成のまとめ実行（設定 → Dependabot → ラベル同期 → Dependabot自動マージ → Issueトリアージ、引数なし。`hasegawa496/repo-ops` の `scripts/repos apply`/`init`/`create` から呼ばれる）
 - `setup-repo-settings.sh`: リポジトリ設定の初期化（ブランチ自動削除など、引数なし）
 - `setup-dependabot.sh`: Dependabot 設定を導入/更新し、PR を自動マージ（引数なし）
 - `setup-label-sync.sh`: ラベル同期 workflow を導入/更新し、起動（引数なし）
 - `setup-triage-project-fields.sh`: Issue トリアージ workflow を導入/更新（引数なし）
 - `setup-dependabot-automerge.sh`: Dependabot 自動マージ workflow を導入/更新し、PR を自動マージ（引数なし、`CI_WORKFLOW_NAME` 環境変数で監視対象の CI workflow 名を指定。既定値 `CI`）
+- `setup-label-sync.sh`/`setup-dependabot-automerge.sh`/`setup-triage-project-fields.sh` の caller workflow 導入部分は `lib/common.sh` の `install_or_skip_caller_workflow` に共通化されている（`hasegawa496/.github` 自身は自己スキップし、`sync-workflow-callers.sh` が別途ローカル参照版を管理する）
 - `sync-workflow-callers.sh`: `workflow-templates/` を元に `.github/workflows/` の呼び出し側 workflow を同期
 - `check-workflow-templates.sh`: `workflow-templates/` の簡易検証（ローカル参照の混在チェック、`@v1` の有無など）
 - `lib/common.sh`: 共通関数（`cd_repo_root`, `ensure_gh_auth`, `ensure_actions_enabled` など）

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -169,3 +169,101 @@ merge_pr_or_fail() {
   show_remote_branch_cleanup_hint "$branch"
   return 1
 }
+
+# 配布用 caller workflow（label-sync.yml など）の導入をまとめて行う共通処理。
+# 導入要否の判定（自己管理repo/既に同一内容）から、ブランチ作成・PR作成・自動マージまでを担う。
+# 戻り値 0 は「呼び出し元は後続処理（workflow起動など）を続けてよい」ことを意味し、
+# 自己管理repoでのスキップ・既に同一内容でのスキップ・導入成功のいずれでも 0 を返す。
+# 1 は導入自体に失敗しており、後続処理を続けるべきではないことを意味する。
+# 個々の setup-*.sh がここで is_self_managed_caller_repo の分岐を持たないようにすることで、
+# 「自己管理repoでも本来必要な後続処理まで一緒にスキップしてしまう」抜け漏れを構造的に防ぐ。
+install_or_skip_caller_workflow() {
+  local repo_full="$1"
+  local expected_content_path="$2"
+  local workflow_path="$3"
+  local default_branch="$4"
+  local branch_prefix="$5"
+  local commit_message="$6"
+  local pr_title="$7"
+  local pr_body="$8"
+
+  if is_self_managed_caller_repo "$repo_full"; then
+    echo "${repo_full} は呼び出し側 workflow を scripts/sync-workflow-callers.sh で自己管理するため、テンプレート導入はスキップします。" >&2
+    return 0
+  fi
+
+  ensure_actions_enabled "$repo_full"
+
+  local needs_apply_template="true"
+  if [[ -f "$workflow_path" ]]; then
+    if ! command -v cmp >/dev/null 2>&1; then
+      echo "既に存在します: $workflow_path（cmp が無いため、テンプレートで更新して導入を続行します）。" >&2
+    elif cmp -s "$workflow_path" "$expected_content_path"; then
+      echo "既に存在します: $workflow_path（同一内容のため、更新不要です）" >&2
+      needs_apply_template="false"
+    fi
+  fi
+
+  if [[ "$needs_apply_template" == "false" ]]; then
+    return 0
+  fi
+
+  ensure_clean_worktree
+  ensure_origin_exists
+
+  local base_ref
+  base_ref="$(ensure_remote_base_ref "$default_branch")"
+
+  local ts branch err
+  ts="$(date -u +%Y%m%d-%H%M%S)"
+  branch="${branch_prefix}-${ts}"
+
+  if git show-ref --verify --quiet "refs/heads/$branch"; then
+    die "ローカルに同名ブランチが存在します: $branch（時間をおいて再実行してください）"
+  fi
+
+  if ! err="$(git checkout -q -b "$branch" "$base_ref" 2>&1)"; then
+    echo "$err" >&2
+    die "ブランチの作成に失敗しました。"
+  fi
+
+  mkdir -p "$(dirname "$workflow_path")"
+  cp "$expected_content_path" "$workflow_path"
+
+  git add "$workflow_path"
+  if ! err="$(git commit -q -m "$commit_message" 2>&1)"; then
+    echo "$err" >&2
+    die "コミットに失敗しました。"
+  fi
+
+  if ! err="$(git push --quiet -u origin "$branch" 2>&1)"; then
+    echo "$err" >&2
+    die "push に失敗しました。リモート/権限/ブランチ保護などを確認してください。"
+  fi
+
+  local pr_number
+  if ! pr_number="$(create_or_get_pr "$default_branch" "$branch" "$pr_title" "$pr_body")"; then
+    return 1
+  fi
+
+  echo "PR をマージします..." >&2
+  if ! merge_pr_or_fail "$pr_number" "$branch" "PR を自動でマージできませんでした。PR を手動でマージしてください。"; then
+    return 1
+  fi
+
+  echo "導入完了: $workflow_path" >&2
+
+  if ! git show-ref --verify --quiet "refs/heads/$default_branch"; then
+    git fetch --quiet origin "$default_branch" >/dev/null 2>&1 || true
+    git checkout -q -B "$default_branch" "origin/$default_branch"
+  else
+    git checkout -q "$default_branch"
+    git pull --ff-only --quiet origin "$default_branch" >/dev/null 2>&1 || true
+  fi
+
+  if git show-ref --verify --quiet "refs/heads/$branch"; then
+    git branch -D "$branch" >/dev/null 2>&1 || true
+  fi
+
+  git push --quiet origin --delete "$branch" >/dev/null 2>&1 || true
+}

--- a/scripts/setup-dependabot-automerge.sh
+++ b/scripts/setup-dependabot-automerge.sh
@@ -15,12 +15,6 @@ cd_repo_root
 ensure_gh_auth
 
 repo_full="$(get_repo_full)"
-
-if is_self_managed_caller_repo "$repo_full"; then
-  echo "${repo_full} は呼び出し側 workflow を scripts/sync-workflow-callers.sh で自己管理するため、導入をスキップします。" >&2
-  exit 0
-fi
-
 ci_workflow_name="${CI_WORKFLOW_NAME:-CI}"
 
 default_branch="$(gh repo view --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || true)"
@@ -38,83 +32,16 @@ trap cleanup EXIT
 cp "$template_workflow" "$expected_workflow"
 sed -i -e "s#workflows: \\[\"CI\"\\]#workflows: [\"${ci_workflow_name}\"]#" "$expected_workflow"
 
-ensure_actions_enabled "$repo_full"
-
 workflow_path=".github/workflows/dependabot-automerge.yml"
-needs_apply_template="true"
 
-if [[ -f "$workflow_path" ]]; then
-  if ! command -v cmp >/dev/null 2>&1; then
-    echo "既に存在します: $workflow_path（cmp が無いため、テンプレートで更新して導入を続行します）。" >&2
-  elif cmp -s "$workflow_path" "$expected_workflow"; then
-    needs_apply_template="false"
-    echo "既に存在します: $workflow_path（同一内容のため、更新不要です）" >&2
-  fi
-fi
-
-if [[ "$needs_apply_template" == "false" ]]; then
-  exit 0
-fi
-
-ensure_clean_worktree
-ensure_origin_exists
-
-base_ref="$(ensure_remote_base_ref "$default_branch")"
-
-ts="$(date -u +%Y%m%d-%H%M%S)"
-branch="chore/update-dependabot-automerge-$ts"
-
-if git show-ref --verify --quiet "refs/heads/$branch"; then
-  die "ローカルに同名ブランチが存在します: $branch（時間をおいて再実行してください）"
-fi
-
-if ! err="$(git checkout -q -b "$branch" "$base_ref" 2>&1)"; then
-  echo "$err" >&2
-  die "ブランチの作成に失敗しました。"
-fi
-
-mkdir -p "$(dirname "$workflow_path")"
-cp "$expected_workflow" "$workflow_path"
-
-git add "$workflow_path"
-if ! err="$(git commit -q -m "chore: Dependabot 自動マージ workflow を導入/更新" 2>&1)"; then
-  echo "$err" >&2
-  die "コミットに失敗しました。"
-fi
-
-if ! err="$(git push --quiet -u origin "$branch" 2>&1)"; then
-  echo "$err" >&2
-  die "push に失敗しました。リモート/権限/ブランチ保護などを確認してください。"
-fi
-
-if ! pr_number="$(create_or_get_pr \
+if ! install_or_skip_caller_workflow \
+  "$repo_full" \
+  "$expected_workflow" \
+  "$workflow_path" \
   "$default_branch" \
-  "$branch" \
+  "chore/update-dependabot-automerge" \
   "chore: Dependabot 自動マージ workflow を導入/更新" \
-  "hasegawa496/.github の Reusable Workflow を呼び出して、CI（\`${ci_workflow_name}\`）成功時に dependabot PR を自動マージできるようにします。")"; then
+  "chore: Dependabot 自動マージ workflow を導入/更新" \
+  "hasegawa496/.github の Reusable Workflow を呼び出して、CI（\`${ci_workflow_name}\`）成功時に dependabot PR を自動マージできるようにします。"; then
   exit 1
 fi
-
-echo "PR をマージします..." >&2
-if ! merge_pr_or_fail \
-  "$pr_number" \
-  "$branch" \
-  "PR を自動でマージできませんでした。PR を手動でマージしてください。"; then
-  exit 1
-fi
-
-echo "導入完了: Dependabot 自動マージ" >&2
-
-if ! git show-ref --verify --quiet "refs/heads/$default_branch"; then
-  git fetch --quiet origin "$default_branch" >/dev/null 2>&1 || true
-  git checkout -q -B "$default_branch" "origin/$default_branch"
-else
-  git checkout -q "$default_branch"
-  git pull --ff-only --quiet origin "$default_branch" >/dev/null 2>&1 || true
-fi
-
-if git show-ref --verify --quiet "refs/heads/$branch"; then
-  git branch -D "$branch" >/dev/null 2>&1 || true
-fi
-
-git push --quiet origin --delete "$branch" >/dev/null 2>&1 || true

--- a/scripts/setup-label-sync.sh
+++ b/scripts/setup-label-sync.sh
@@ -74,12 +74,6 @@ repo_full="$(get_repo_full)"
 default_branch="$(gh repo view --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || true)"
 default_branch="${default_branch:-main}"
 
-if is_self_managed_caller_repo "$repo_full"; then
-  echo "${repo_full} は呼び出し側 workflow を scripts/sync-workflow-callers.sh で自己管理するため、テンプレート導入はスキップし、起動のみ行います。" >&2
-  run_label_sync_workflow "$default_branch"
-  exit $?
-fi
-
 # このスクリプト自身（my-life）のテンプレートを正本として利用する。
 # 想定実行: my-life を clone した状態で、対象リポジトリ上から相対/絶対パスで本スクリプトを呼ぶ。
 template_workflow="$script_dir/../workflow-templates/label-sync.yml"
@@ -87,105 +81,24 @@ if [[ ! -f "$template_workflow" ]]; then
   die "テンプレートが見つかりません: $template_workflow"
 fi
 
-# 期待値（既に同じものがあれば「起動だけ」で済ませる）。
 expected_workflow="$(mktemp -t label-sync.XXXXXX)"
 cleanup() { rm -f "$expected_workflow"; }
 trap cleanup EXIT
 
 cp "$template_workflow" "$expected_workflow"
 
-# Actions が無効なら、可能なら API で有効化し、無理なら案内して中断する。
-ensure_actions_enabled "$repo_full"
-
 workflow_path=".github/workflows/label-sync.yml"
-needs_apply_template="true"
 
-if [[ -f "$workflow_path" ]]; then
-  if ! command -v cmp >/dev/null 2>&1; then
-    echo "既に存在します: $workflow_path（cmp が無いため、テンプレートで更新して導入を続行します）。" >&2
-  else
-    if cmp -s "$workflow_path" "$expected_workflow"; then
-      needs_apply_template="false"
-      echo "既に存在します: $workflow_path（同一内容のため、起動のみ実施します）" >&2
-    fi
-  fi
-fi
-
-if [[ "$needs_apply_template" == "false" ]]; then
-  run_label_sync_workflow "$default_branch"
-  exit 0
-fi
-
-# ここから先は workflow の導入/更新が必要な場合（ブランチ作成/コミット/push を行う）。
-ensure_clean_worktree
-ensure_origin_exists
-
-# 事故防止: 必ずデフォルトブランチを最新化してから、そこを起点に専用ブランチを切る。
-base_ref="$(ensure_remote_base_ref "$default_branch")"
-
-ts="$(date -u +%Y%m%d-%H%M%S)"
-branch="chore/update-label-sync-$ts"
-
-if git show-ref --verify --quiet "refs/heads/$branch"; then
-  die "ローカルに同名ブランチが存在します: $branch（時間をおいて再実行してください）"
-fi
-
-if ! err="$(git checkout -q -b "$branch" "$base_ref" 2>&1)"; then
-  echo "$err" >&2
-  die "ブランチの作成に失敗しました。"
-fi
-
-mkdir -p "$(dirname "$workflow_path")"
-cp "$expected_workflow" "$workflow_path"
-
-git add "$workflow_path"
-if ! err="$(git commit -q -m "chore: Label Sync workflow を導入/更新" 2>&1)"; then
-  echo "$err" >&2
-  die "コミットに失敗しました。"
-fi
-
-if ! err="$(git push --quiet -u origin "$branch" 2>&1)"; then
-  echo "$err" >&2
-  die "push に失敗しました。リモート/権限/ブランチ保護などを確認してください。"
-fi
-
-if ! pr_number="$(create_or_get_pr \
+if ! install_or_skip_caller_workflow \
+  "$repo_full" \
+  "$expected_workflow" \
+  "$workflow_path" \
   "$default_branch" \
-  "$branch" \
+  "chore/update-label-sync" \
   "chore: Label Sync workflow を導入/更新" \
-  "hasegawa496/.github の Reusable Workflow を呼び出して、ラベルを同期できるようにします。")"; then
+  "chore: Label Sync workflow を導入/更新" \
+  "hasegawa496/.github の Reusable Workflow を呼び出して、ラベルを同期できるようにします。"; then
   exit 1
 fi
 
-# ここから先は「できたらやる」。失敗しても原因を表示して案内する。
-echo "PR をマージします..." >&2
-if ! merge_pr_or_fail \
-  "$pr_number" \
-  "$branch" \
-  "PR を自動でマージできませんでした。PR を手動でマージした後、Actions から 'Label Sync' を実行してください。"; then
-  exit 1
-fi
-
-echo "マージ完了。workflow を起動します..." >&2
-
-if ! run_label_sync_workflow "$default_branch"; then
-  exit 1
-fi
-
-echo "後片付けをします（ローカルブランチの削除など）..." >&2
-
-# ローカルブランチは GitHub の設定（delete_branch_on_merge）では消えないため、
-# ここで明示的に消します。作業ブランチ上にいる場合はデフォルトブランチへ戻します。
-if ! git show-ref --verify --quiet "refs/heads/$default_branch"; then
-  git fetch --quiet origin "$default_branch" >/dev/null 2>&1 || true
-  git checkout -q -B "$default_branch" "origin/$default_branch"
-else
-  git checkout -q "$default_branch"
-fi
-
-if git show-ref --verify --quiet "refs/heads/$branch"; then
-  git branch -D "$branch" >/dev/null 2>&1 || true
-fi
-
-# リモートブランチ削除は gh 側で試みていますが、残っている場合に備えて念のため実施します。
-git push --quiet origin --delete "$branch" >/dev/null 2>&1 || true
+run_label_sync_workflow "$default_branch"

--- a/scripts/setup-triage-project-fields.sh
+++ b/scripts/setup-triage-project-fields.sh
@@ -27,72 +27,21 @@ trap cleanup EXIT
 
 cp "$template_workflow" "$expected_workflow"
 
-ensure_actions_enabled "$repo_full"
-
 workflow_path=".github/workflows/triage.yml"
-needs_apply_template="true"
 
-if [[ -f "$workflow_path" ]]; then
-  if ! command -v cmp >/dev/null 2>&1; then
-    echo "既に存在します: $workflow_path（cmp が無いため、テンプレートで更新して導入を続行します）。" >&2
-  elif cmp -s "$workflow_path" "$expected_workflow"; then
-    needs_apply_template="false"
-    echo "既に存在します: $workflow_path（同一内容のため、更新不要です）" >&2
-  fi
-fi
-
-if [[ "$needs_apply_template" == "false" ]]; then
-  exit 0
-fi
-
-ensure_clean_worktree
-ensure_origin_exists
-
-base_ref="$(ensure_remote_base_ref "$default_branch")"
-
-ts="$(date -u +%Y%m%d-%H%M%S)"
-branch="chore/update-triage-$ts"
-
-if git show-ref --verify --quiet "refs/heads/$branch"; then
-  die "ローカルに同名ブランチが存在します: $branch（時間をおいて再実行してください）"
-fi
-
-if ! err="$(git checkout -q -b "$branch" "$base_ref" 2>&1)"; then
-  echo "$err" >&2
-  die "ブランチの作成に失敗しました。"
-fi
-
-mkdir -p "$(dirname "$workflow_path")"
-cp "$expected_workflow" "$workflow_path"
-
-git add "$workflow_path"
-if ! err="$(git commit -q -m "chore: Triage workflow を導入/更新" 2>&1)"; then
-  echo "$err" >&2
-  die "コミットに失敗しました。"
-fi
-
-if ! err="$(git push --quiet -u origin "$branch" 2>&1)"; then
-  echo "$err" >&2
-  die "push に失敗しました。リモート/権限/ブランチ保護などを確認してください。"
-fi
-
-if ! pr_number="$(create_or_get_pr \
+if ! install_or_skip_caller_workflow \
+  "$repo_full" \
+  "$expected_workflow" \
+  "$workflow_path" \
   "$default_branch" \
-  "$branch" \
+  "chore/update-triage" \
   "chore: Triage workflow を導入/更新" \
-  $'Issue 作成/編集時に Projects v2 へ追加し、Issue フォーム（優先度/Size）の値を Project フィールドへ反映します。\n\n前提:\n- Secrets: PROJECT_TOKEN\n- Project フィールド: 優先度（Single select）, Size（Single select: XS/S/M/L/XL）')"; then
+  "chore: Triage workflow を導入/更新" \
+  $'Issue 作成/編集時に Projects v2 へ追加し、Issue フォーム（優先度/Size）の値を Project フィールドへ反映します。\n\n前提:\n- Secrets: PROJECT_TOKEN\n- Project フィールド: 優先度（Single select）, Size（Single select: XS/S/M/L/XL）'; then
   exit 1
 fi
 
-echo "PR をマージします..." >&2
-if ! merge_pr_or_fail \
-  "$pr_number" \
-  "$branch" \
-  "PR を自動でマージできませんでした。PR を手動でマージしてください。"; then
-  exit 1
-fi
-
-echo "マージ完了。workflow の認識待ち..." >&2
+echo "workflow の認識待ち..." >&2
 for attempt in 1 2 3 4 5 6 7 8 9 10; do
   if gh workflow view triage.yml >/dev/null 2>&1; then
     break

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -12,6 +12,7 @@ assert_no_args "$@"
 "$script_dir/setup-dependabot.sh"
 "$script_dir/setup-label-sync.sh"
 "$script_dir/setup-dependabot-automerge.sh"
+"$script_dir/setup-triage-project-fields.sh"
 
 # git hooks を有効化する（コミット前に shellcheck を自動実行）
 git config core.hooksPath .githooks


### PR DESCRIPTION
## 背景

PR #31 で「自己管理repo（hasegawa496/.github自身）への早期exitが、後続の必要な処理（Label Sync起動）まで一緒にスキップしてしまう」という見落としをCodexレビューで指摘された。この見落としは `is_self_managed_caller_repo` の分岐を各 `setup-*.sh` が個別に実装していたことが一因。

## 変更内容

1. **共通化**: `lib/common.sh` に `install_or_skip_caller_workflow` を追加し、caller workflow 配布の一連処理（自己管理repo判定 → 既存内容比較 → ブランチ作成 → PR作成 → 自動マージ → 後片付け）を集約する。`setup-label-sync.sh` / `setup-dependabot-automerge.sh` はこの共通関数を呼ぶだけにし、個別に `is_self_managed_caller_repo` 分岐を持たない設計にする。戻り値 0 =「後続処理（workflow起動など）を続けてよい」、1 = 導入失敗、という契約にすることで、自己管理repoでも本来必要な後続処理を書き忘れにくくする。
2. **Issueトリアージの統合**: `setup-triage-project-fields.sh` も同じ共通関数を使うよう書き換え、`setup.sh` に組み込む。これにより `hasegawa496/repo-ops` の `scripts/repos apply`/`init`/`create` が新規・既存repo問わず同じ経路でIssueトリアージも導入できるようになる（従来は `hasegawa496/repo-ops` 側の個別スクリプト `rollout-triage-workflow.sh` でのみ導入していた）。

## 関連

- `hasegawa496/repo-ops` 側では、`scripts/repos apply`/`init`/`create` の共通処理（`run_shared_standard_setup`）に、対象repoの主worktreeが汚れていても実行できるようworktree分離を追加する変更を別PRで進めている。これにより `rollout-triage-workflow.sh`（worktree分離を個別実装していた）は不要になり削除する予定。

## テスト

- [x] `bash -n` 全ファイル / `shellcheck`（pre-commit hookで実行）
- [x] `scripts/check-workflow-templates.sh`
- [x] 実機確認: `hasegawa496/.github` 自身で `setup-label-sync.sh` / `setup-dependabot-automerge.sh` / `setup-triage-project-fields.sh` を実行し、テンプレート導入はスキップしつつ必要な後続処理（Label Sync起動、workflow認識確認）が行われることを確認
- [ ] 非自己管理repo（通常の配布先）への導入フロー自体は、既存の動作確認済みロジックをそのまま移設したのみで、実リポジトリへの導入実行はしていない（実行するとPR作成・自動マージが走るため）