### PR TITLE
fix: 自己利用のCI同期順を修正する

### DIFF
--- a/scripts/sync-workflow-callers.sh
+++ b/scripts/sync-workflow-callers.sh
@@ -75,10 +75,15 @@ has_ci_workflow() {
 
 while IFS= read -r -d '' src; do
   dst="${src#templates/}"
-  if [[ "$src" == "templates/.github/workflows/ci.yml" ]] && has_ci_workflow; then
+  if [[ "$src" == "templates/.github/workflows/ci.yml" ]]; then
     continue
   fi
   render "$src" "$dst"
 done < <(find templates -type f -print0 | sort -z)
+
+# 自己利用する検証 workflow は name: CI に変換されるため、先に同期してから判定する。
+if ! has_ci_workflow; then
+  render "templates/.github/workflows/ci.yml" ".github/workflows/ci.yml"
+fi
 
 echo "OK: templates/ から自己利用設定を同期しました（$mode）"


### PR DESCRIPTION
自己利用の検証 workflow を `name: CI` に変換する前にダミー CI を照合していたため、テンプレート検証が不整合として失敗していました。CI 判定を自己利用 caller の同期後へ移動します。