### PR TITLE
fix: 個人アカウントownerでtriage-reusable.ymlのProject取得が失敗する不具合を修正する

### DIFF
--- a/.github/workflows/triage-reusable.yml
+++ b/.github/workflows/triage-reusable.yml
@@ -144,8 +144,11 @@ jobs:
               }
             }'
 
-          project_json="$(GH_TOKEN="${PROJECT_TOKEN}" gh api graphql -f query="$project_query" -F owner="${PROJECT_OWNER}" -F number="${PROJECT_NUMBER}")"
-          project_obj="$(jq -c '.data.organization.projectV2 // .data.user.projectV2 // empty' <<<"$project_json")"
+          # owner が個人アカウントの場合、organization フィールドの解決失敗により
+          # graphql の errors が返り gh api graphql が非ゼロ終了するが、
+          # data 自体は取得できているため、exit code ではなく取得データの有無で成否判定する。
+          project_json="$(GH_TOKEN="${PROJECT_TOKEN}" gh api graphql -f query="$project_query" -F owner="${PROJECT_OWNER}" -F number="${PROJECT_NUMBER}" 2>/dev/null || true)"
+          project_obj="$(jq -c '.data.organization.projectV2 // .data.user.projectV2 // empty' <<<"${project_json:-{}}" 2>/dev/null || true)"
           if [[ -z "$project_obj" ]]; then
             comment "Project（${PROJECT_OWNER}/${PROJECT_NUMBER}）の取得に失敗しました。owner/番号が正しいか確認してください。"
             exit 0


### PR DESCRIPTION
## 概要

`triage-reusable.yml` の Project 取得クエリは `organization(login:$owner)` と `user(login:$owner)` を同一 GraphQL クエリ内で問い合わせている。owner（例: `hasegawa496`）が個人アカウントの場合、`organization` フィールド解決時に GraphQL の `errors` が返り、`gh api graphql` は `data` が部分的に取得できていても非ゼロ終了する。`set -euo pipefail` 下ではこの exit code によりスクリプト全体が中断し、`user` 側の `projectV2` が正常取得できるケースでも Triage が失敗していた（フォールバックコメントも投稿されない）。

- `gh api graphql` の呼び出しを exit code で失敗判定せず、既存の「取得データ（`project_obj`）の有無で成否判定する」ロジックに合わせて修正
- 完全失敗ケース（トークン不正等）では従来通りフォールバックコメント分岐に到達することを実データで確認済み

Closes #39

## テスト

- [x] `bash -n` / ShellCheck（run: ブロック抽出、新規warningなし）
- [x] `gh api graphql` の実際の部分エラーレスポンス（個人アカウントowner再現）で修正後ロジックが `user` 側データを正しく取得できることを確認
- [x] 完全失敗（無効トークン）でも従来通りフォールバックコメント分岐に到達することを確認
- [x] `scripts/check-workflow-templates.sh`
- [x] `scripts/sync-workflow-callers.sh --write`（差分なし）