### PR TITLE
fix: updateProjectV2ItemFieldValueがGraphQL変数型不一致で失敗する不具合を修正する

### DIFF
--- a/.github/workflows/triage-reusable.yml
+++ b/.github/workflows/triage-reusable.yml
@@ -227,12 +227,12 @@ jobs:
           fi
 
           update_mutation='
-            mutation($projectId:ID!, $itemId:ID!, $fieldId:ID!, $value:ProjectV2FieldValue!){
+            mutation($projectId:ID!, $itemId:ID!, $fieldId:ID!, $optionId:String!){
               updateProjectV2ItemFieldValue(input:{
                 projectId:$projectId,
                 itemId:$itemId,
                 fieldId:$fieldId,
-                value:$value
+                value:{ singleSelectOptionId:$optionId }
               }){
                 projectV2Item { id }
               }
@@ -242,7 +242,7 @@ jobs:
               -F projectId="${project_id}" \
               -F itemId="${item_id}" \
               -F fieldId="${priority_field_id}" \
-              -f value="$(jq -nc --arg id "${priority_option_id}" '{singleSelectOptionId:$id}')" >/dev/null; then
+              -F optionId="${priority_option_id}" >/dev/null; then
             comment "Project の優先度フィールド更新に失敗しました（権限不足の可能性があります）。\n\n- 推定: 優先度=${priority_opt}\n\nIssue: ${issue_url}"
             exit 0
           fi
@@ -251,7 +251,7 @@ jobs:
               -F projectId="${project_id}" \
               -F itemId="${item_id}" \
               -F fieldId="${size_field_id}" \
-              -f value="$(jq -nc --arg id "${size_option_id}" '{singleSelectOptionId:$id}')" >/dev/null; then
+              -F optionId="${size_option_id}" >/dev/null; then
             comment "Project の Size フィールド更新に失敗しました（権限不足の可能性があります）。\n\n- 推定: Size=${size_opt}\n\nIssue: ${issue_url}"
             exit 0
           fi


### PR DESCRIPTION
## 概要

`updateProjectV2ItemFieldValue`ミューテーションは`$value: ProjectV2FieldValue!`（入力オブジェクト型）を変数宣言しているが、呼び出し側は`gh api graphql -f value=$(jq -nc ...)`でJSON文字列を渡していた。`-f/--raw-field`は常に文字列として送信するため、GraphQL側で型不一致エラー（`Variable $value ... was provided invalid value`）となり、Priority/SizeフィールドへのProject反映が常に失敗していた。

hasegawa496/repo-ops#41 での実行確認（テスト用Issue）で発覚。認証(401)とフィールド名不一致(#41)が直った後に初めてこの層まで到達し顕在化した。

## 変更内容

- `$value`を廃止し、末端の選択肢IDのみを`$optionId(String!)`として受け取る
- ミューテーション側で`value:{ singleSelectOptionId:$optionId }`とインラインで組み立てる
- 呼び出し側は`-f value=$(jq -nc ...)`→`-F optionId=...`に変更

## テスト

- [x] `bash -n` / ShellCheck（run:ブロック抽出、新規warningなし）
- [x] `scripts/check-workflow-templates.sh`
- [x] YAML妥当性確認

## 関連

- hasegawa496/repo-ops#41