### PR TITLE
docs: ダミーCIの配布方針を更新する

### DIFF
--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -34,7 +34,7 @@
 2. Reusable Workflow と配布テンプレートを変更する。
 3. `scripts/sync-workflow-callers.sh --write` でこのリポジトリ用の呼び出し側を同期する。
 4. `scripts/check-workflow-templates.sh` と対象 Workflow に対応する検証を実行する。
-5. `repo-ops` の `apply` で配布する。既存の `CI` は保持し、存在しない場合だけダミー `CI` を配置する。
+5. `repo-ops` の `apply` で配布する。既存の `CI` は保持し、存在しない場合は既存検証の有無にかかわらず発火専用のダミー `CI` を配置する。
 
 ## 提供する Workflow
 

--- a/docs/reusable-workflows/ci.md
+++ b/docs/reusable-workflows/ci.md
@@ -16,4 +16,4 @@ CI が未整備のリポジトリでも、Dependabot Auto-merge の `workflow_ru
 ## 位置づけ
 
 - Reusable Workflow ではなく、配布テンプレート `templates/.github/workflows/ci.yml` のみを持つ命名規約の例外である（経緯は [ADR 0002](../adr/0002-template-distribution-and-ci-name.md)）。
-- `repo-ops` の `apply` は、`name: CI` を持つ workflow が存在しないリポジトリだけに配布する。既存の `CI` はダミーで上書きしない。
+- `repo-ops` の `apply` は、`name: CI` を持つ workflow が存在しないリポジトリに配布する。`ShellCheck` や `Test` など既存の検証 workflow は名前を変えずに保持する。既存の `CI` はダミーで上書きしない。


### PR DESCRIPTION
## 概要

既存の検証Workflowを`CI`へ統合せず、発火専用のダミーCIを追加する配布方針を明文化する。

## 検証

- `scripts/check-workflow-templates.sh`