### PR TITLE
fix: Project既存アイテム確認の失敗時にコメントを残すようにする

### DIFF
--- a/.github/workflows/triage-reusable.yml
+++ b/.github/workflows/triage-reusable.yml
@@ -196,7 +196,7 @@ jobs:
               }
             }'
           if ! existing_items_json="$(GH_TOKEN="${PROJECT_TOKEN}" gh api graphql -f query="$existing_item_query" -F contentId="${ISSUE_NODE_ID}" 2>/dev/null)"; then
-            comment "Issue の既存 Project アイテム確認に失敗しました（PROJECT_TOKEN に repo スコープ、またはこのリポジトリへの Issue 読み取り権限が不足している可能性があります）。\n\nIssue: ${issue_url}"
+            comment "Issue の既存 Project アイテム確認に失敗しました（PROJECT_TOKEN の Project アクセス権限が不足している可能性があります）。\n\nIssue: ${issue_url}"
             exit 0
           fi
           item_id="$(jq -r --arg pid "$project_id" '.data.node.projectItems.nodes[]? | select(.project.id==$pid) | .id' <<<"$existing_items_json" | head -n1)"

--- a/.github/workflows/triage-reusable.yml
+++ b/.github/workflows/triage-reusable.yml
@@ -195,7 +195,10 @@ jobs:
                 }
               }
             }'
-          existing_items_json="$(GH_TOKEN="${PROJECT_TOKEN}" gh api graphql -f query="$existing_item_query" -F contentId="${ISSUE_NODE_ID}")"
+          if ! existing_items_json="$(GH_TOKEN="${PROJECT_TOKEN}" gh api graphql -f query="$existing_item_query" -F contentId="${ISSUE_NODE_ID}" 2>/dev/null)"; then
+            comment "Issue の既存 Project アイテム確認に失敗しました（PROJECT_TOKEN に repo スコープ、またはこのリポジトリへの Issue 読み取り権限が不足している可能性があります）。\n\nIssue: ${issue_url}"
+            exit 0
+          fi
           item_id="$(jq -r --arg pid "$project_id" '.data.node.projectItems.nodes[]? | select(.project.id==$pid) | .id' <<<"$existing_items_json" | head -n1)"
 
           if [[ -z "${item_id:-}" ]]; then


### PR DESCRIPTION
## 概要

`triage-reusable.yml` の `existing_items_json` 取得だけ、他の `gh api graphql` 呼び出しと違って `if !`/`comment`/`exit 0` のガードが付いておらず、`set -euo pipefail` 下で失敗すると Issue にコメントを残さないままジョブごと死んでいた。

hasegawa496/dev-env-setup#132 の Triage 失敗（`PROJECT_TOKEN` の権限不足と推測）調査中に発覚。他の呼び出しと同じパターンに揃えて、失敗時に理由がわかるコメントを Issue に残すようにした。

## Test plan

- [x] `bash -n` で `run:` ブロックの構文確認
- [x] `shellcheck` で新規の警告が増えていないことを確認
- [x] pre-commit の workflow template 検証（templates/ と reusable workflow の整合性チェック）に合格
- [ ] `PROJECT_TOKEN` の権限不足を再現できるリポジトリで Triage を実行し、失敗コメントが投稿されることを確認