### PR TITLE
feat: Triage workflowでIssueのアサインを自動化する

### DIFF
--- a/.github/workflows/triage-reusable.yml
+++ b/.github/workflows/triage-reusable.yml
@@ -1,6 +1,8 @@
-# Issue を Project に追加し、優先度/Size を自動設定する Reusable Workflow
+# Issue をアサインし Project に追加し、優先度/Size を自動設定する Reusable Workflow
 #
 # 目的:
+#   - Issue 作成時に repo owner を自動アサイン（Issue Form の assignees が効かない
+#     CLI 起票（gh issue create）を補完する。既にアサイン済みなら何もしない）
 #   - Issue 作成時に Project（Projects v2）へ自動追加
 #   - Issue フォームの入力内容から Project のフィールドを更新（優先度/Size）
 #
@@ -50,11 +52,13 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - name: Project へ追加しフィールドを更新
+      - name: アサインし Project へ追加しフィールドを更新
         env:
           REPO: ${{ github.repository }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_NODE_ID: ${{ github.event.issue.node_id }}
+          EVENT_ACTION: ${{ github.event.action }}
+          DEFAULT_ASSIGNEE: ${{ github.repository_owner }}
           PROJECT_OWNER: ${{ inputs.project_owner || github.repository_owner }}
           PROJECT_NUMBER: ${{ inputs.project_number }}
           PRIORITY_FIELD_NAME: ${{ inputs.priority_field_name }}
@@ -75,6 +79,21 @@ jobs:
           issue_title="$(jq -r '.title // ""' <<<"$issue_json")"
           issue_body="$(jq -r '.body // ""' <<<"$issue_json")"
           issue_url="$(jq -r '.html_url // ""' <<<"$issue_json")"
+          issue_assignees="$(jq -r '[.assignees[].login] | join(",")' <<<"$issue_json")"
+
+          # Issue Form の assignees は Web UI 起票時しか適用されず、CLI 起票（gh issue create）では
+          # 抜けるため、ここで補完する。既にアサイン済みなら触らない。opened 以外で動かさないのは、
+          # 意図的に外したアサインを本文編集（edited）で復活させないため。
+          # Project 更新と違い issues: write だけで足りるので、PROJECT_TOKEN の判定より前に行う。
+          if [[ "${EVENT_ACTION}" == "opened" && -z "$issue_assignees" ]]; then
+            GH_TOKEN="${GITHUB_TOKEN}" gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/assignees" \
+              -f "assignees[]=${DEFAULT_ASSIGNEE}" >/dev/null 2>&1 || true
+            # アサイン API は権限の無いユーザーを指定しても成功扱いで無視するため、結果を確認する
+            assigned_now="$(GH_TOKEN="${GITHUB_TOKEN}" gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq '[.assignees[].login] | join(",")' 2>/dev/null || true)"
+            if [[ -z "$assigned_now" ]]; then
+              comment "${DEFAULT_ASSIGNEE} をアサインできませんでした。リポジトリへの権限を確認してください。\n\nIssue: ${issue_url}"
+            fi
+          fi
 
           extract_first_line_under_heading() {
             local heading="$1"


### PR DESCRIPTION
## 背景

Issue Form の `assignees` は Web UI 起票時しか適用されず、CLI 起票（`gh issue create`）では抜ける。このため `issue-create` Skill 側が `--assignee` を明示して補完していた。

しかし全 Issue テンプレート（bug / feature / improvement / task / documentation）の `assignees` は `hasegawa496`（= `github.repository_owner`）で固定であり、Skill の「type ごとにフォームから assignees を読む」という分岐は実質的に意味を持っていなかった。定数を Skill に判断させている状態だった。

## 変更内容

Triage workflow 側で assignee を補完する。

- 対象は `opened` かつ既存 assignee が空の場合のみ
- アサイン先は `github.repository_owner`
- 失敗時は既存の `comment()` と同じ形式で Issue にコメントする

## 設計上の判断

- **既にアサイン済みなら触らない**: Web UI 起票では Issue Form が既に assignee を設定するため、workflow は冪等な補完として働く。手動で別の担当者を設定したケースも壊さない。
- **`opened` のときだけ動かす**: トリガーには `edited` も含まれるため、意図的に外したアサインを本文編集で復活させないようにする。
- **`PROJECT_TOKEN` の判定より前に配置**: アサインは `issues: write` だけで足りる。`PROJECT_TOKEN` 未設定時の早期 `exit 0` より後ろに置くと、トークン未設定のリポジトリでアサインまで巻き添えで止まる。
- **`assignee` の input は追加していない**: 現時点で owner 以外を指定したいケースが存在しないため。必要になった時点で追加しても後方互換で入れられる。
- **アサイン結果を検証する**: アサイン API は push 権限の無いユーザーを指定しても成功扱いで無視するため、実際に設定されたかを確認してからコメントする。

## 影響範囲

`triage.yml` は全16リポジトリに配布済みで、`repos apply` / `init` / `create` の標準テンプレートにも含まれる。呼び出し側（`templates/.github/workflows/triage.yml`）の変更は不要。

追従して `hasegawa496/dotclaude` の `issue-create` Skill から assignee 関連の記述を削除する（別 PR）。

## 動作確認

- `python3 -c "yaml.safe_load(...)"` で YAML 構文を確認
- `run` ブロックを抽出して `bash -n` と `shellcheck` を実行。追加分に指摘なし（残る指摘は既存の `issue_title` 未使用と GraphQL クエリの意図的なシングルクォート）

🤖 Generated with [Claude Code](https://claude.com/claude-code)