### PR TITLE
fix: ShellCheckを.sh変更時だけ発火させる

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+# GENERATED: scripts/sync-workflow-callers.sh により生成
+# CI が未整備のリポジトリ用の最小 workflow。
+# 既に name: CI を持つ workflow がある場合は配布しない。
+# マージ可否の gate ではなく、Dependabot Auto-merge の workflow_run を
+# 必ず発火させるトリガー保証である（docs/reusable-workflows/ci.md）。
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  success:
+    runs-on: ubuntu-latest
+    steps:
+      - run: true

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -4,13 +4,19 @@
 # 推奨:
 #   - このファイルを対象リポジトリの `.github/workflows/shellcheck.yml` としてコピーしてください。
 
-name: CI
+name: ShellCheck
 
 on:
   pull_request:
+    paths:
+      - '**/*.sh'
+      - '.github/workflows/shellcheck.yml'
   push:
     branches:
       - main
+    paths:
+      - '**/*.sh'
+      - '.github/workflows/shellcheck.yml'
 
 permissions:
   contents: read

--- a/docs/github-workflow-operations.md
+++ b/docs/github-workflow-operations.md
@@ -11,7 +11,8 @@
 - Auto-merge の待機対象は常に workflow 名 `CI` とする。
 - `CI` がないリポジトリには、成功だけを返すダミー `CI` を配置する。
 - 既に `name: CI` があるリポジトリではダミーを配置せず、既存の実 CI を保持する。
-- `ShellCheck`、`Rust CI`、`Test` など既存検証を `CI` に統合する作業は、対象リポジトリごとの変更として進める。
+- `Rust CI`、`Test` など既存検証を `CI` に統合する作業は、対象リポジトリごとの変更として進める。
+- `ShellCheck` は `CI` に統合しない。`shellcheck.yml` は `.sh` 変更時だけ発火する path フィルタを持つため、常時発火が必要な `CI` とは実行条件が異なる。`ci.yml` 側に `shellcheck` ジョブを追加すると path フィルタが効かず二重実行になる。
 
 ## PROJECT_TOKEN
 

--- a/docs/reusable-workflows/shellcheck.md
+++ b/docs/reusable-workflows/shellcheck.md
@@ -6,7 +6,14 @@
 
 ## 実行条件
 
-配布する `shellcheck.yml` は pull request と `main` への push で実行する。
+配布する `shellcheck.yml` は pull request と `main` への push で、`**/*.sh` または
+`.github/workflows/shellcheck.yml` に変更があった場合だけ実行する。`.sh` を変更しない
+変更で発火させないことで、GitHub Actions の課金分数を抑える
+（`repo-ops` の `docs/github-actions-cost-governance.md` 参照）。
+
+この path フィルタがあるため、`shellcheck.yml` は Dependabot Auto-merge の待機先である
+workflow 名 `CI` には使えない。`.github` 自身を含め、`CI` は常に発火するダミー
+（[CI（ダミー）](ci.md)）か各リポジトリ固有の CI が担う。
 
 ## 入力と権限
 

--- a/scripts/sync-workflow-callers.sh
+++ b/scripts/sync-workflow-callers.sh
@@ -41,10 +41,6 @@ render() {
     -e 's#uses:[[:space:]]*hasegawa496/\.github/\.github/workflows/\([^[:space:]@]\+\)@[^[:space:]]\+#uses: ./.github/workflows/\1#g' \
     "$out"
 
-  if [[ "$src" == "templates/.github/workflows/shellcheck.yml" ]]; then
-    sed -i -e 's/^name: ShellCheck$/name: CI/' "$out"
-  fi
-
   if [[ "$src" == "templates/.github/workflows/"* ]] && ! head -n 1 "$out" | rg -q 'GENERATED'; then
     { echo "# GENERATED: scripts/sync-workflow-callers.sh により生成"; cat "$out"; } >"$out.new"
     mv "$out.new" "$out"

--- a/templates/.github/workflows/shellcheck.yml
+++ b/templates/.github/workflows/shellcheck.yml
@@ -7,9 +7,15 @@ name: ShellCheck
 
 on:
   pull_request:
+    paths:
+      - '**/*.sh'
+      - '.github/workflows/shellcheck.yml'
   push:
     branches:
       - main
+    paths:
+      - '**/*.sh'
+      - '.github/workflows/shellcheck.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## 背景

`repo-ops` 側の Actions コスト再計測（2026-07-28）で、配布テンプレートの `shellcheck.yml` に path フィルタが無く、`.sh` を1行も変更しない push / PR でも無条件に発火・課金されていることが判明した。JS/Astro 中心のリポジトリではシェルスクリプトの変更頻度が低く、ほとんどの実行がムダ撃ちになっている。

参照: `hasegawa496/repo-ops` の `docs/github-actions-cost-governance.md`

## 変更内容

- `templates/.github/workflows/shellcheck.yml` に path フィルタ（`**/*.sh`、`.github/workflows/shellcheck.yml`）を追加する
- `scripts/sync-workflow-callers.sh` から、`.github` 自身の `shellcheck.yml` を `name: ShellCheck` から `name: CI` へ書き換える特例を削除する
- 上記に伴い `.github` 自身へダミー `CI`（`.github/workflows/ci.yml`）が生成される
- `docs/reusable-workflows/shellcheck.md` と `docs/github-workflow-operations.md` を更新する

## 特例を削除する理由

`.github` は自身の `shellcheck.yml` を `name: CI` として使っていた。ここに path フィルタが入ると、`.sh` を変更しない PR で `CI` が発火せず、`CI` の `workflow_run` を待つ Dependabot Auto-merge が `.github` で機能しなくなる。

`.github` も他リポジトリと同じく「常時発火するダミー CI + path フィルタ付き ShellCheck」の構成へ揃えることで解消する。この構成は ADR 0002 の「`.github` 自身も配布対象とし、Reusable Workflow の参照だけをローカル参照へ変換する」とも整合する。

課金面では、`.sh` 以外の変更時に走るジョブが「実 ShellCheck 1件」から「ダミー CI 1件」へ置き換わるだけで、`.github` の消費分数は増えない。

## 確認

- `scripts/sync-workflow-callers.sh --write` 実行済み
- `scripts/check-workflow-templates.sh` 合格
- `bash -n` / `shellcheck -x` 合格

## 後続作業

- `repo-ops` 側で CLI の同特例を削除し、`repos apply` で全リポジトリへ配布する
- `repo-ops` / `dotclaude` の `ci.yml` に埋め込まれた重複 `shellcheck` ジョブを削除する

🤖 Generated with [Claude Code](https://claude.com/claude-code)