### PR TITLE
fix: Triageのreopenedトリガーを外す

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -13,7 +13,10 @@ name: Triage
 
 on:
   issues:
-    types: [opened, edited, reopened]
+    # reopened は含めない。本文が変わらないため、アサインは opened 限定で対象外、
+    # Project は既存 item を再利用、優先度/Size は同じ値の書き直しとなり、
+    # 何も変わらないまま1分課金されるだけである。
+    types: [opened, edited]
 
 permissions:
   contents: read

--- a/docs/reusable-workflows/triage.md
+++ b/docs/reusable-workflows/triage.md
@@ -34,8 +34,13 @@ CLI で `--body` を直接指定して起票する場合は Issue Forms を経�
 
 ## Triage workflow（`triage.yml` → `triage-reusable.yml`）の役割
 
-- トリガー: `issues: [opened, edited, reopened]`（起票経路に依存せず、Web UI /
+- トリガー: `issues: [opened, edited]`（起票経路に依存せず、Web UI /
   CLI いずれの Issue にも反応する）
+  - `reopened` は含めない。reopen 時は本文が変わらないため、アサインは `opened`
+    限定で対象外、Project は既存 item を再利用、優先度 / Size は同じ値の書き直しと
+    なり、状態が何も変わらないまま 1 分課金されるだけである
+  - `edited` は残す。本文の `### 優先度` / `### Size` を後から直したときに
+    Project へ反映する必要があるため
 - 処理:
   1. Issue 本文から `### 優先度` / `### Size` 見出し直下の最初の非空行を抽出する
   2. `優先度` は `P0`〜`P3` で始まる値（Issue Form のフル表記 `P0: 緊急` や

--- a/templates/.github/workflows/triage.yml
+++ b/templates/.github/workflows/triage.yml
@@ -12,7 +12,10 @@ name: Triage
 
 on:
   issues:
-    types: [opened, edited, reopened]
+    # reopened は含めない。本文が変わらないため、アサインは opened 限定で対象外、
+    # Project は既存 item を再利用、優先度/Size は同じ値の書き直しとなり、
+    # 何も変わらないまま1分課金されるだけである。
+    types: [opened, edited]
 
 permissions:
   contents: read


### PR DESCRIPTION
## 背景

`reopened` で Triage が動いても、Issue の状態は何も変わらない。

| 処理 | reopen 時の挙動 |
|---|---|
| owner のアサイン | `if EVENT_ACTION == "opened"` で明示的に対象外 |
| Project への追加 | 既存 item を再利用するため何もしない |
| 優先度 / Size の設定 | 本文が変わっていないため同じ値の書き直し |

それでもジョブは動くため 1 分課金される。GitHub Actions の課金はジョブ単位で 1 分未満を切り上げるため（[Actions runner pricing](https://docs.github.com/en/billing/reference/actions-runner-pricing)）、実処理が数秒でも 1 分かかる。

## 変更内容

- `templates/.github/workflows/triage.yml` のトリガーを `[opened, edited, reopened]` から `[opened, edited]` にする
- `docs/reusable-workflows/triage.md` に判断理由を記載する
- `scripts/sync-workflow-callers.sh --write` で自己利用側を同期する

`edited` は残す。本文の `### 優先度` / `### Size` を後から直したときに Project へ反映する機能があるためである。

## 削減量について

大きくはない。2026-07 の実測では Triage の実行が 159 回（private 16 リポジトリ）に対し、同期間の Issue 作成は 184 件（public の `.github` を含む）だった。実行回数のほうが少ないため、`edited` と `reopened` の寄与はもともと小さい。

不要な処理を止める妥当性のための変更であり、削減額を目的にしたものではない。

## 反映タイミング

トリガーは呼び出し側テンプレートにあるため、Reusable Workflow の `runs-on` 変更（#60）と違い `@main` 参照では反映されない。各リポジトリへ `repos apply` で配布する必要がある。

配布だけで 16 リポジトリ分の PR と CI（約 64 分）がかかり、本変更単体では削減量を上回る。**配布は他のテンプレート変更とまとめて 1 回で行う。**

## 確認

- `scripts/check-workflow-templates.sh` 合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)