### PR TITLE
docs: 検証系を単一ジョブへ統合する設計をADR 0003として起こす

### DIFF
--- a/docs/adr/0003-consolidate-verification-into-single-job.md
+++ b/docs/adr/0003-consolidate-verification-into-single-job.md
@@ -1,0 +1,140 @@
+# ADR 0003: 検証系ワークフローを単一ジョブへ統合する
+
+## ステータス
+
+提案。
+
+## 背景
+
+GitHub Actions の課金は**ジョブ単位で 1 分未満を切り上げる**（[Actions runner pricing](https://docs.github.com/en/billing/reference/actions-runner-pricing)）。ワークフロー単位でも実行時間比例でもない。
+
+`hasegawa496/repo-ops` で 2026-07 の全 2,932 run のジョブを取得して実測した結果、private 16 リポジトリの課金 2,721 分に対し実処理は 935 分で、**1,786 分（66%）が切り上げによる上乗せ**だった。根拠は `hasegawa496/repo-ops` の `docs/github-actions-cost-analysis-2026-07.md` に置く。
+
+ADR 0001 と ADR 0002 で採用した「機能ごとに Reusable Workflow を分け、`templates/` から配布する」構成は、そのまま**ジョブ本数**に直結している。Reusable Workflow は `jobs.<job_id>.uses` で呼ぶため、呼び出しごとに独立したジョブになり、切り上げが 1 回ずつ発生する。同じ検証を 2 ワークフローに分けると、実処理が合計 27 秒でも 2 分課金される。
+
+PR への push 1 回あたりの現状のジョブ数は次のとおりである。
+
+| リポジトリ | 現状のジョブ構成（PR 時） | ジョブ数 |
+| --- | --- | --- |
+| visual-caret-move | ダミー CI + Test（lint / test） + ShellCheck | 4 |
+| dilemma-procyon | ダミー CI + PR タイトル検証 + PR ビルド検証 + ShellCheck | 3〜4 |
+| secure-sync | ダミー CI + Rust CI + ShellCheck | 3 |
+| air-innovate-site | CI（quality / bun-compat） + ShellCheck | 3 |
+| ai-tools-knowledge / bright-moon-shingetsu / bright-moon-site / headless_cms / misa-player / dotclaude / repo-ops | CI + ShellCheck | 2 |
+| ai-chat-platform / ai-quota-hud / dev-env-setup / my-life / win-dev-bootstrap | ダミー CI + ShellCheck | 2 |
+
+さらに 2 点、実測で判明した無駄がある。
+
+- **`.sh` を 1 つも持たないリポジトリでも ShellCheck が走っている。** ai-chat-platform、ai-quota-hud、bright-moon-shingetsu、bright-moon-site、misa-player、my-life、win-dev-bootstrap の 7 リポジトリは `.sh` が 0 件で、`find` して 0 件で即終了するだけのジョブに月 153 分を払っている
+- **`.sh` を持つリポジトリでも、変更されるのは稀である。** 2026-07 に作成された PR 496 件のうち `.sh` を含むものは 60 件（12%）だけだった
+
+## 決定
+
+### 1. ShellCheck を Reusable Workflow から composite action へ移す
+
+`.github/actions/shellcheck/action.yml` を新設し、`.github/workflows/shellcheck-reusable.yml` と配布テンプレート `templates/.github/workflows/shellcheck.yml` を廃止する。
+
+Reusable Workflow（`jobs.<job_id>.uses`）は必ず独立したジョブになるが、composite action（`steps.uses`）は呼び出し元ジョブの中で動くため、ジョブ本数を増やさない。1 つのジョブに `uses` は 1 つしか書けず、`steps` と併用もできないため、複数の Reusable Workflow を 1 ジョブにまとめることは構造上できない。
+
+`shellcheck` は `ubuntu-latest`（0.9.0）、`ubuntu-26.04`（0.11.0）、`ubuntu-slim`（0.9.0）のいずれにも同梱されているため、composite action ではインストール処理を持たない。現行 Reusable の `sudo apt-get install shellcheck` は到達しない死んだコードであり、`ubuntu-slim` の非特権コンテナでは失敗する。
+
+### 2. 各リポジトリの検証を `name: CI` の単一ワークフロー・単一ジョブへ集約する
+
+`Rust CI`、`Test`、`PR ビルド検証`、`PR タイトル検証` のように別ファイルへ分かれている検証は、`ci.yml` の同一ジョブへステップとして統合する。ADR 0002 の「既存検証を段階的に `CI` へ統合する」を、ジョブ単位まで踏み込んで確定させる。
+
+並列実行による短縮より、切り上げ回数の削減を優先する。実測ではどのリポジトリも CI の実処理が 2 分未満であり、直列化による待ち時間の増加は許容できる。
+
+### 3. CI を持たないリポジトリへ配布する `ci.yml` を実検証にする
+
+現在の `run: true` のダミーを、checkout と ShellCheck composite action の呼び出しに置き換える。`.sh` が無いリポジトリでは composite action が数秒で終了するため、実質的にこれまでのダミーと同じ役割（Dependabot Auto-merge の `workflow_run` を発火させる）を果たす。
+
+ダミー専用のワークフローを別に持たないことで、「`CI` が実検証を兼ねる」という状態に全リポジトリを揃える。
+
+### 4. `push: main` を CI から外す
+
+Free プランの private リポジトリでは branch protection と ruleset が使えず（ADR 0001 関連）、`main` の検証結果をマージ可否の gate に使っていない。実運用でも `main` の実行結果は確認していない。
+
+2026-07 の実測では `main` への 524 コミットのうち 518 件が PR 経由であり、非 PR の 6 件も 4 件が `Initial commit`、1 件が初期セットアップだった。実質的な直接 push は 1 件である。直接 push の防止は `pre-push` フックへ移す（`hasegawa496/repo-ops` の Issue #74）。
+
+除外するのは次の 2 つとする。
+
+- release-please 系（secure-sync、visual-caret-move、dilemma-procyon）。`push: main` がリリース PR 生成の起点そのものである
+- `E2E NextCloud`（secure-sync）。トリガーの要否は別途 `hasegawa496/secure-sync` の Issue #211 で判断する
+
+### 5. `runs-on` は検証内容で選ぶ
+
+| 検証内容 | ランナー |
+| --- | --- |
+| ShellCheck だけ、または `gh` / `jq` 程度 | `ubuntu-slim`（$0.002/分） |
+| ビルド・テストを伴う | `ubuntu-latest`（$0.006/分） |
+
+判断基準は `docs/github-workflow-operations.md` の「ランナーの選び方」に従う。
+
+### 6. ガバナンスは `repos` CLI の check で担保する
+
+`ci.yml` は実検証を含むためリポジトリ固有になり、`templates/` から配布できるのは CI を持たないリポジトリの分だけである。統合状態の維持は配布ではなく検査で担保する。
+
+`hasegawa496/repo-ops` に `repos ci check` を追加し、次を検証する。違反は報告のみとし、自動修正はしない。
+
+- `name: CI` の workflow が 1 つだけ存在する
+- `CI` のジョブが 1 本である
+- `CI` の `on:` に `push: main` が含まれない（release 系リポジトリの除外は台帳で管理する）
+- `.sh` を持つリポジトリは、`CI` のジョブに ShellCheck composite action のステップを含む
+- `shellcheck.yml` が残っていない
+
+### 7. 命名と対応関係
+
+Reusable Workflow の命名規約（ADR 0001）に、composite action の規約を追加する。
+
+| 種別 | パス | 役割 |
+| --- | --- | --- |
+| composite action | `actions/<用途名>/action.yml` | 呼び出し元ジョブの中でステップとして動く |
+| 個別仕様 | `docs/actions/<用途名>.md` | 目的、入力、前提を定義する |
+
+`scripts/check-workflow-templates.sh` は、`actions/<用途名>/action.yml` に対応する `docs/actions/<用途名>.md` の存在も検証する。
+
+## 理由
+
+課金の単位がジョブであり、実処理の 66% が切り上げで嵩上げされている以上、削減できるのはジョブ本数だけである。ジョブを速くする施策は効果を持たない。
+
+composite action は、共通化を維持したままジョブ本数を増やさない唯一の手段である。ShellCheck を各リポジトリへコピーすれば同じ効果は得られるが、修正が全リポジトリへ届かなくなり ADR 0001 で解決した問題が再発する。
+
+path フィルタで `shellcheck.yml` の発火を絞る案も検討した。実測では PR の 88% が `.sh` を変更しないため月 323 分の削減が見込めるが、composite action 化（月 367 分）に対して 44 分下回るうえ、`shellcheck.yml` を独立ワークフローとして残す構成が固定される。両者は排他であり、効果が大きく将来の追加検証にも効く composite action 化を採る。
+
+## 結果
+
+PR への push 1 回あたりのジョブ数が全リポジトリで 1 になる。`hasegawa496/repo-ops` の実測を基準にすると、2026-07 の 2,721 分は次のように推移する見込みである。
+
+| 段階 | 課金 |
+| --- | --- |
+| 現状 | 2,721 分 |
+| 検証系を 1 ジョブへ統合 | 1,869 分 |
+| `push: main` を削除 | 1,485 分 |
+| Label Sync の起動抑制（対応済み） | 1,255 分 |
+
+無料枠 2,000 分に対して余裕ができ、`ubuntu-slim` への移行分がさらに超過時の単価を下げる。
+
+失うものは次のとおりである。
+
+- **ジョブ単位の切り分けが落ちる。** ShellCheck の失敗とテストの失敗が同じジョブの中に並ぶ。ステップ名で判別する
+- **並列実行が無くなる。** 実処理が 2 分未満のため実害は小さいが、将来重い検証を足す場合は分割の是非を再検討する
+- **`ci.yml` がリポジトリ固有になる。** 配布では維持できないため、`repos ci check` による検査が前提になる
+
+## 移行
+
+一度に全リポジトリへ適用しない。`repos apply` による配布は 16 リポジトリ分の PR と CI（約 64 分）を伴うため、テンプレート変更をまとめて 1 回で行う。
+
+1. `.github` に composite action と `docs/actions/shellcheck.md` を追加する（このリポジトリ内で完結、public のため無料）
+2. `templates/.github/workflows/ci.yml` を実検証版へ差し替え、`shellcheck.yml` を配布物から削除する
+3. `hasegawa496/repo-ops` に `repos ci check` を追加する
+4. 利用頻度の高いリポジトリから、`ci.yml` への統合を個別 PR で行う
+5. 残りのリポジトリは翌月の `repos apply` でまとめて配布・移行する
+
+`shellcheck-reusable.yml` は、全リポジトリの移行が完了し参照が無くなったことを確認してから削除する。ADR 0001 のタグ削除と同じ手順を踏む。
+
+## 検討した代替案
+
+- **`shellcheck.yml` に path フィルタを追加する。** 変更量は最小だが効果が composite action 化を下回り、独立ワークフロー構成が固定されるため採用しない
+- **ShellCheck を各リポジトリへ直接コピーする。** ジョブ本数は同じく 1 になるが、修正が全リポジトリへ届かず ADR 0001 の問題が再発するため採用しない
+- **重い検証だけ別ジョブに残し、軽い検証を `ubuntu-slim` の別ジョブにまとめる。** ジョブを分けた時点で最低 1 分の切り上げが増えるため、同一ジョブへの統合より常に高くなる。採用しない
+- **`ci.yml` を完全に配布可能な形にし、リポジトリ固有の検証を `scripts/ci.sh` へ寄せる。** 配布で維持できる利点はあるが、mise / bun / cargo / uv のセットアップとキャッシュが action に依存しており、シェルスクリプトへ移すとキャッシュを失う。採用しない

--- a/docs/adr/0003-consolidate-verification-into-single-job.md
+++ b/docs/adr/0003-consolidate-verification-into-single-job.md
@@ -1,8 +1,8 @@
-# ADR 0003: 検証系ワークフローを単一ジョブへ統合する
+# ADR 0003: CI で動く Reusable Workflow を廃止し検証を単一ジョブへ統合する
 
 ## ステータス
 
-提案。
+検討中。決定 1・2（下記）は方向性として固いが、配布方法とダミー CI の扱いに未解決の論点が残る。「未解決の検討事項」節を参照。
 
 ## 背景
 
@@ -10,9 +10,17 @@ GitHub Actions の課金は**ジョブ単位で 1 分未満を切り上げる**�
 
 `hasegawa496/repo-ops` で 2026-07 の全 2,932 run のジョブを取得して実測した結果、private 16 リポジトリの課金 2,721 分に対し実処理は 935 分で、**1,786 分（66%）が切り上げによる上乗せ**だった。根拠は `hasegawa496/repo-ops` の `docs/github-actions-cost-analysis-2026-07.md` に置く。
 
-ADR 0001 と ADR 0002 で採用した「機能ごとに Reusable Workflow を分け、`templates/` から配布する」構成は、そのまま**ジョブ本数**に直結している。Reusable Workflow は `jobs.<job_id>.uses` で呼ぶため、呼び出しごとに独立したジョブになり、切り上げが 1 回ずつ発生する。同じ検証を 2 ワークフローに分けると、実処理が合計 27 秒でも 2 分課金される。
+したがってジョブを速くしても効果はほとんど無く、**PR への push 1 回あたりのジョブ本数を減らすことだけが有効**である。目標は全リポジトリで 1 本にすることとする。
 
-PR への push 1 回あたりの現状のジョブ数は次のとおりである。
+その前提として外せないのが、**Reusable Workflow は構造上ジョブを共有できない**という制約である。
+
+- Reusable Workflow は `jobs.<job_id>.uses` で呼ぶ。呼び出しごとに独立したジョブになる
+- 1 つのジョブに `uses` は 1 つしか書けず、`steps` との併用もできない
+- したがって複数の Reusable Workflow を 1 ジョブへまとめることはできない
+
+現在 CI の一部として動いている Reusable Workflow は ShellCheck だけである。これが残る限り、どのリポジトリも最低 2 ジョブになる。ADR 0001 と ADR 0002 で採用した「機能ごとに Reusable Workflow を分けて配布する」構成が、そのままジョブ本数に直結している。
+
+PR への push 1 回あたりの現状は次のとおりである。
 
 | リポジトリ | 現状のジョブ構成（PR 時） | ジョブ数 |
 | --- | --- | --- |
@@ -23,68 +31,42 @@ PR への push 1 回あたりの現状のジョブ数は次のとおりである
 | ai-tools-knowledge / bright-moon-shingetsu / bright-moon-site / headless_cms / misa-player / dotclaude / repo-ops | CI + ShellCheck | 2 |
 | ai-chat-platform / ai-quota-hud / dev-env-setup / my-life / win-dev-bootstrap | ダミー CI + ShellCheck | 2 |
 
-さらに 2 点、実測で判明した無駄がある。
-
-- **`.sh` を 1 つも持たないリポジトリでも ShellCheck が走っている。** ai-chat-platform、ai-quota-hud、bright-moon-shingetsu、bright-moon-site、misa-player、my-life、win-dev-bootstrap の 7 リポジトリは `.sh` が 0 件で、`find` して 0 件で即終了するだけのジョブに月 153 分を払っている
-- **`.sh` を持つリポジトリでも、変更されるのは稀である。** 2026-07 に作成された PR 496 件のうち `.sh` を含むものは 60 件（12%）だけだった
-
 ## 決定
 
-### 1. ShellCheck を Reusable Workflow から composite action へ移す
+### 1. ShellCheck の Reusable Workflow を廃止し composite action へ置き換える（前提）
 
 `.github/actions/shellcheck/action.yml` を新設し、`.github/workflows/shellcheck-reusable.yml` と配布テンプレート `templates/.github/workflows/shellcheck.yml` を廃止する。
 
-Reusable Workflow（`jobs.<job_id>.uses`）は必ず独立したジョブになるが、composite action（`steps.uses`）は呼び出し元ジョブの中で動くため、ジョブ本数を増やさない。1 つのジョブに `uses` は 1 つしか書けず、`steps` と併用もできないため、複数の Reusable Workflow を 1 ジョブにまとめることは構造上できない。
+composite action は `steps.uses` で使うため呼び出し元ジョブの中で動き、ジョブ本数を増やさない。1 つのジョブに何個でも並べられる。これが 1 ジョブ化の前提であり、他のすべての決定はここから派生する。
 
 `shellcheck` は `ubuntu-latest`（0.9.0）、`ubuntu-26.04`（0.11.0）、`ubuntu-slim`（0.9.0）のいずれにも同梱されているため、composite action ではインストール処理を持たない。現行 Reusable の `sudo apt-get install shellcheck` は到達しない死んだコードであり、`ubuntu-slim` の非特権コンテナでは失敗する。
 
-### 2. 各リポジトリの検証を `name: CI` の単一ワークフロー・単一ジョブへ集約する
+### 2. Reusable Workflow は「ジョブを共有できないもの」に限る
+
+今後の追加時に同じ問題を繰り返さないため、使い分けの基準を定める。
+
+| 条件 | 手段 |
+| --- | --- |
+| CI と同じイベント（`pull_request`）で動き、CI のジョブに同居できる | **composite action** |
+| CI と別のイベントで動き、ジョブを共有できない | Reusable Workflow |
+
+この基準により、Triage（`issues`）、Label Sync（`workflow_dispatch`）、Dependabot Auto-merge（`workflow_run`）は Reusable Workflow のまま維持する。これらは CI のジョブに同居できないため、統合しても本数は減らない。
+
+### 3. 各リポジトリの検証を `name: CI` の単一ワークフロー・単一ジョブへ集約する
 
 `Rust CI`、`Test`、`PR ビルド検証`、`PR タイトル検証` のように別ファイルへ分かれている検証は、`ci.yml` の同一ジョブへステップとして統合する。ADR 0002 の「既存検証を段階的に `CI` へ統合する」を、ジョブ単位まで踏み込んで確定させる。
 
 並列実行による短縮より、切り上げ回数の削減を優先する。実測ではどのリポジトリも CI の実処理が 2 分未満であり、直列化による待ち時間の増加は許容できる。
 
-### 3. CI を持たないリポジトリへ配布する `ci.yml` を実検証にする
+### 4. 配布する `ci.yml` のダミーを実検証にする（検討中）
 
-現在の `run: true` のダミーを、checkout と ShellCheck composite action の呼び出しに置き換える。`.sh` が無いリポジトリでは composite action が数秒で終了するため、実質的にこれまでのダミーと同じ役割（Dependabot Auto-merge の `workflow_run` を発火させる）を果たす。
+現在の `run: true` を、checkout と ShellCheck composite action の呼び出しに置き換える案。`.sh` が無いリポジトリでは composite action が数秒で終了するため、これまでのダミーと同じ役割（Dependabot Auto-merge の `workflow_run` を発火させる）を果たせる見込みである。
 
-ダミー専用のワークフローを別に持たないことで、「`CI` が実検証を兼ねる」という状態に全リポジトリを揃える。
+ただしこれは「ダミー CI」という現在の位置づけ自体を変えることになる（「未解決の検討事項」B 参照）。また、この変更を全リポジトリへ行き渡らせるには配布側の削除の仕組みが要る（同 A 参照）。この 2 点が解決してから確定する。
 
-### 4. `push: main` を CI から外す
+### 5. composite action の命名と対応関係を定める
 
-Free プランの private リポジトリでは branch protection と ruleset が使えず（ADR 0001 関連）、`main` の検証結果をマージ可否の gate に使っていない。実運用でも `main` の実行結果は確認していない。
-
-2026-07 の実測では `main` への 524 コミットのうち 518 件が PR 経由であり、非 PR の 6 件も 4 件が `Initial commit`、1 件が初期セットアップだった。実質的な直接 push は 1 件である。直接 push の防止は `pre-push` フックへ移す（`hasegawa496/repo-ops` の Issue #74）。
-
-除外するのは次の 2 つとする。
-
-- release-please 系（secure-sync、visual-caret-move、dilemma-procyon）。`push: main` がリリース PR 生成の起点そのものである
-- `E2E NextCloud`（secure-sync）。トリガーの要否は別途 `hasegawa496/secure-sync` の Issue #211 で判断する
-
-### 5. `runs-on` は検証内容で選ぶ
-
-| 検証内容 | ランナー |
-| --- | --- |
-| ShellCheck だけ、または `gh` / `jq` 程度 | `ubuntu-slim`（$0.002/分） |
-| ビルド・テストを伴う | `ubuntu-latest`（$0.006/分） |
-
-判断基準は `docs/github-workflow-operations.md` の「ランナーの選び方」に従う。
-
-### 6. ガバナンスは `repos` CLI の check で担保する
-
-`ci.yml` は実検証を含むためリポジトリ固有になり、`templates/` から配布できるのは CI を持たないリポジトリの分だけである。統合状態の維持は配布ではなく検査で担保する。
-
-`hasegawa496/repo-ops` に `repos ci check` を追加し、次を検証する。違反は報告のみとし、自動修正はしない。
-
-- `name: CI` の workflow が 1 つだけ存在する
-- `CI` のジョブが 1 本である
-- `CI` の `on:` に `push: main` が含まれない（release 系リポジトリの除外は台帳で管理する）
-- `.sh` を持つリポジトリは、`CI` のジョブに ShellCheck composite action のステップを含む
-- `shellcheck.yml` が残っていない
-
-### 7. 命名と対応関係
-
-Reusable Workflow の命名規約（ADR 0001）に、composite action の規約を追加する。
+ADR 0001 の Reusable Workflow の規約に、composite action の規約を追加する。
 
 | 種別 | パス | 役割 |
 | --- | --- | --- |
@@ -93,26 +75,28 @@ Reusable Workflow の命名規約（ADR 0001）に、composite action の規約�
 
 `scripts/check-workflow-templates.sh` は、`actions/<用途名>/action.yml` に対応する `docs/actions/<用途名>.md` の存在も検証する。
 
+### 6. 統合状態は配布ではなく検査で担保する
+
+`ci.yml` は実検証を含むためリポジトリ固有になり、`templates/` から配布できるのは CI を持たないリポジトリの分だけである。
+
+`hasegawa496/repo-ops` に `repos ci check` を追加し、次を検証する。違反は報告のみとし、自動修正はしない。
+
+- `name: CI` の workflow が 1 つだけ存在する
+- `CI` のジョブが 1 本である
+- `.sh` を持つリポジトリは、`CI` のジョブに ShellCheck composite action のステップを含む
+- `shellcheck.yml` が残っていない
+
 ## 理由
 
-課金の単位がジョブであり、実処理の 66% が切り上げで嵩上げされている以上、削減できるのはジョブ本数だけである。ジョブを速くする施策は効果を持たない。
+課金の単位がジョブであり、実処理の 66% が切り上げで嵩上げされている以上、削減できるのはジョブ本数だけである。そして Reusable Workflow が CI の一部として残る限り、ジョブ本数は 1 にできない。決定 1 は目標達成の必要条件である。
 
-composite action は、共通化を維持したままジョブ本数を増やさない唯一の手段である。ShellCheck を各リポジトリへコピーすれば同じ効果は得られるが、修正が全リポジトリへ届かなくなり ADR 0001 で解決した問題が再発する。
+composite action は、共通化を維持したままジョブ本数を増やさない唯一の手段である。ShellCheck を各リポジトリへコピーしても本数は 1 になるが、修正が全リポジトリへ届かなくなり ADR 0001 で解決した問題が再発する。
 
-path フィルタで `shellcheck.yml` の発火を絞る案も検討した。実測では PR の 88% が `.sh` を変更しないため月 323 分の削減が見込めるが、composite action 化（月 367 分）に対して 44 分下回るうえ、`shellcheck.yml` を独立ワークフローとして残す構成が固定される。両者は排他であり、効果が大きく将来の追加検証にも効く composite action 化を採る。
+決定 2 は、同じ判断を将来くり返さないための基準である。「共通化したいから Reusable Workflow」ではなく「ジョブを共有できるかどうか」で選ぶ。
 
 ## 結果
 
-PR への push 1 回あたりのジョブ数が全リポジトリで 1 になる。`hasegawa496/repo-ops` の実測を基準にすると、2026-07 の 2,721 分は次のように推移する見込みである。
-
-| 段階 | 課金 |
-| --- | --- |
-| 現状 | 2,721 分 |
-| 検証系を 1 ジョブへ統合 | 1,869 分 |
-| `push: main` を削除 | 1,485 分 |
-| Label Sync の起動抑制（対応済み） | 1,255 分 |
-
-無料枠 2,000 分に対して余裕ができ、`ubuntu-slim` への移行分がさらに超過時の単価を下げる。
+PR への push 1 回あたりのジョブ数が全リポジトリで 1 になる。`hasegawa496/repo-ops` の実測を基準にすると、統合だけで 2,721 分が 1,869 分になる見込みである。
 
 失うものは次のとおりである。
 
@@ -120,21 +104,61 @@ PR への push 1 回あたりのジョブ数が全リポジトリで 1 になる
 - **並列実行が無くなる。** 実処理が 2 分未満のため実害は小さいが、将来重い検証を足す場合は分割の是非を再検討する
 - **`ci.yml` がリポジトリ固有になる。** 配布では維持できないため、`repos ci check` による検査が前提になる
 
-## 移行
+## 非対象
 
-一度に全リポジトリへ適用しない。`repos apply` による配布は 16 リポジトリ分の PR と CI（約 64 分）を伴うため、テンプレート変更をまとめて 1 回で行う。
+本 ADR はジョブ本数だけを対象とする。次はコスト対策ではあるがジョブ本数とは独立であり、別途決める。
 
-1. `.github` に composite action と `docs/actions/shellcheck.md` を追加する（このリポジトリ内で完結、public のため無料）
-2. `templates/.github/workflows/ci.yml` を実検証版へ差し替え、`shellcheck.yml` を配布物から削除する
-3. `hasegawa496/repo-ops` に `repos ci check` を追加する
-4. 利用頻度の高いリポジトリから、`ci.yml` への統合を個別 PR で行う
-5. 残りのリポジトリは翌月の `repos apply` でまとめて配布・移行する
+- **`push: main` トリガーの削除。** 発火回数の問題であり、ジョブ本数の問題ではない
+- **`runs-on` の選択。** 単価の問題である。基準は `docs/github-workflow-operations.md` の「ランナーの選び方」で確定済み
+- **`.sh` を持たないリポジトリでの ShellCheck の要否。** 決定 4 により composite action が数秒で終了するため、ジョブ本数には影響しない
 
-`shellcheck-reusable.yml` は、全リポジトリの移行が完了し参照が無くなったことを確認してから削除する。ADR 0001 のタグ削除と同じ手順を踏む。
+## 移行（暫定案、未解決の検討事項の結論待ち）
+
+一度に全リポジトリへ適用しない見込み。`repos apply` による配布は 16 リポジトリ分の PR と CI（約 64 分）を伴うため、テンプレート変更をまとめて 1 回で行う想定である。
+
+1. `.github` に composite action と `docs/actions/shellcheck.md` を追加し、`scripts/check-workflow-templates.sh` を拡張する（このリポジトリ内で完結、public のため無料）
+2. 配布先の `shellcheck.yml` を消す仕組みを用意する（未解決の検討事項 A）
+3. `templates/.github/workflows/ci.yml` の扱いを、未解決の検討事項 B・C の結論に基づいて決める
+4. `hasegawa496/repo-ops` に `repos ci check` を追加する
+5. 利用頻度の高いリポジトリから、`ci.yml` への統合を個別 PR で行う
+6. 残りのリポジトリは翌月の `repos apply` でまとめて配布・移行する
+7. 全リポジトリの移行完了と参照が無いことを確認してから `shellcheck-reusable.yml` を削除する
+
+最後の削除は ADR 0001 のタグ削除と同じ手順を踏む。移行途中は composite action と Reusable Workflow が併存するが、`shellcheck-reusable.yml` は変更せず残すため、未移行リポジトリの動作には影響しない。
+
+## 未解決の検討事項
+
+以下は、この ADR の議論の中で見えているが、まだ結論を出していない。次にこの ADR を扱うときはここから続きを検討する。
+
+### A. 配布は「削除」を扱えない
+
+`copy_shared_templates`（`hasegawa496/repo-ops` の `src/repository_ops_cli/cli.py`）は `templates/` を走査してコピーするだけで、**削除を扱わない**。`templates/` から `shellcheck.yml` を消しても、既に配布済みの各リポジトリの `.github/workflows/shellcheck.yml` は残り続ける。
+
+残ったままだと ShellCheck の Reusable Workflow 呼び出しが動き続け、1 ジョブ化が成立しない。1 ジョブ化には配布側に「テンプレートから消えたファイルを配布先からも消す」削除の仕組みが必須だが、その設計はまだ無い。
+
+一度配布すると後から消すのが難しくなる懸念があるため、配布メカニズムを変える前に、この削除の仕組みを先に用意できるかを詰める必要がある。
+
+### B. ダミー CI は「標準 CI」と呼ぶべきかもしれない
+
+ダミー CI（`run: true`）の唯一の役割は、Dependabot Auto-merge が待つ workflow 名 `CI` を発火させることであり、中身は重要でない。決定 4 で ShellCheck composite action の呼び出しに置き換える案を挙げたが、そうなると「ダミー」ではなく実体のある標準 CI になる。
+
+この位置づけの変更を、早い段階で Issue化すべきという指摘がある。`ci.yml` を持たないリポジトリでも「何もしない」のではなく「最低限 ShellCheck だけは検証する」という要件がもともとあったはずで、ダミー CI という命名・位置づけ自体を見直す余地がある。
+
+### C. Dependabot Auto-merge が `workflow_run` を使う理由の裏取りが未了
+
+auto-merge が `pull_request` ではなく `workflow_run` 経由で CI 完了を監視しているのは、Dependabot が作った PR では `GITHUB_TOKEN` が読み取り専用になるためと推測しているが、未確認である。
+
+この前提が正しければダミー CI は構造上必要で、`.sh` も実 CI も無いリポジトリ（ai-chat-platform、ai-quota-hud、my-life、win-dev-bootstrap）は PR ごとに最低 1 分を払い続ける。
+
+もし読み取り専用の制約が無ければ、auto-merge を `pull_request` トリガーに寄せられる可能性がある。その場合 Dependabot 以外のアクターはジョブレベルの `if:` でスキップ（＝非課金）でき、ダミー CI 自体が不要になり、上記 4 リポジトリの月あたりの課金が追加で減る。
+
+### D. 配布可否の判断基準が未定
+
+「実 CI を持つリポジトリへ composite action 呼び出しの 1 行をいつ・どう入れるか」の判断基準が無い。前回の分析では対象は 5 リポジトリ（ai-tools-knowledge、air-innovate-site、dotclaude、headless_cms、repo-ops）で、手動追加で足りるとしたが、リポジトリ数が増えた場合にどう判断するか（自動検出するか、`repos ci check` の失敗を起票のトリガーにするか）は決めていない。
 
 ## 検討した代替案
 
-- **`shellcheck.yml` に path フィルタを追加する。** 変更量は最小だが効果が composite action 化を下回り、独立ワークフロー構成が固定されるため採用しない
-- **ShellCheck を各リポジトリへ直接コピーする。** ジョブ本数は同じく 1 になるが、修正が全リポジトリへ届かず ADR 0001 の問題が再発するため採用しない
-- **重い検証だけ別ジョブに残し、軽い検証を `ubuntu-slim` の別ジョブにまとめる。** ジョブを分けた時点で最低 1 分の切り上げが増えるため、同一ジョブへの統合より常に高くなる。採用しない
+- **`shellcheck.yml` に path フィルタを追加する。** ジョブ本数は 2 のままで、発火回数を減らす案である。実測では PR の 88% が `.sh` を変更しないため月 323 分の削減が見込めるが、composite action 化（月 367 分）を下回るうえ、1 ジョブ化の目標には到達しない。両者は排他であり採用しない
+- **ShellCheck を各リポジトリへ直接コピーする。** 本数は 1 になるが、修正が全リポジトリへ届かず ADR 0001 の問題が再発するため採用しない
+- **軽い検証だけ別ジョブに残し `ubuntu-slim` を使う。** ジョブを分けた時点で最低 1 分の切り上げが増えるため、同一ジョブへの統合より常に高くなる。採用しない
 - **`ci.yml` を完全に配布可能な形にし、リポジトリ固有の検証を `scripts/ci.sh` へ寄せる。** 配布で維持できる利点はあるが、mise / bun / cargo / uv のセットアップとキャッシュが action に依存しており、シェルスクリプトへ移すとキャッシュを失う。採用しない

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -46,4 +46,15 @@
 
 設計判断の経緯は [ADR 0001](adr/0001-reusable-workflow-reference-and-naming.md)、[ADR 0002](adr/0002-template-distribution-and-ci-name.md)、[ADR 0003](adr/0003-consolidate-verification-into-single-job.md) を参照します。
 
-ADR 0003 により、検証系は Reusable Workflow ではなく composite action で共通化し、各リポジトリの `name: CI` 単一ジョブへ統合する方針です。Reusable Workflow は `jobs.<job_id>.uses` で呼ぶため必ず独立したジョブになり、GitHub Actions の 1 分未満切り上げ課金がジョブごとに発生します。イベントが独立していてジョブを共有できないもの（Triage、Label Sync、Dependabot Auto-merge）は Reusable Workflow のまま維持します。
+## Reusable Workflow と composite action の使い分け
+
+ADR 0003 により、共通化の手段は「ジョブを共有できるかどうか」で選びます。
+
+| 条件 | 手段 |
+| --- | --- |
+| CI と同じイベント（`pull_request`）で動き、CI のジョブに同居できる | composite action（`actions/<用途名>/action.yml`） |
+| CI と別のイベントで動き、ジョブを共有できない | Reusable Workflow（`.github/workflows/<用途名>-reusable.yml`） |
+
+Reusable Workflow は `jobs.<job_id>.uses` で呼ぶため必ず独立したジョブになり、GitHub Actions の 1 分未満切り上げ課金がジョブごとに発生します。1 つのジョブに `uses` は 1 つしか書けず `steps` とも併用できないため、複数の Reusable Workflow を 1 ジョブへまとめることはできません。
+
+「共通化したいから Reusable Workflow」ではなく、ジョブを共有できるなら composite action を選びます。Triage、Label Sync、Dependabot Auto-merge はイベントが独立しており CI のジョブに同居できないため、Reusable Workflow のまま維持します。

--- a/docs/reusable-workflows.md
+++ b/docs/reusable-workflows.md
@@ -44,4 +44,6 @@
 - [Dependabot Auto-merge](reusable-workflows/dependabot-automerge.md)
 - [CI（ダミー）](reusable-workflows/ci.md)（Reusable Workflow ではなく配布テンプレートのみの例外）
 
-設計判断の経緯は [ADR 0001](adr/0001-reusable-workflow-reference-and-naming.md) と [ADR 0002](adr/0002-template-distribution-and-ci-name.md) を参照します。
+設計判断の経緯は [ADR 0001](adr/0001-reusable-workflow-reference-and-naming.md)、[ADR 0002](adr/0002-template-distribution-and-ci-name.md)、[ADR 0003](adr/0003-consolidate-verification-into-single-job.md) を参照します。
+
+ADR 0003 により、検証系は Reusable Workflow ではなく composite action で共通化し、各リポジトリの `name: CI` 単一ジョブへ統合する方針です。Reusable Workflow は `jobs.<job_id>.uses` で呼ぶため必ず独立したジョブになり、GitHub Actions の 1 分未満切り上げ課金がジョブごとに発生します。イベントが独立していてジョブを共有できないもの（Triage、Label Sync、Dependabot Auto-merge）は Reusable Workflow のまま維持します。


### PR DESCRIPTION
## 概要

検証系ワークフローを `name: CI` の単一ジョブへ統合する設計を ADR 0003 として起こす。実装は含まない。**設計のレビューをお願いしたい。**

## なぜ必要か

GitHub Actions の課金は**ジョブ単位で 1 分未満を切り上げる**（[Actions runner pricing](https://docs.github.com/en/billing/reference/actions-runner-pricing)）。

2026-07 の全 2,932 run を実測した結果、private 16 リポジトリの課金 2,721 分に対し**実処理は 935 分**で、**1,786 分（66%）が切り上げによる上乗せ**だった。ジョブを速くしても効果は無く、ジョブ本数を減らすことだけが有効である。

ADR 0001 / 0002 で採用した「機能ごとに Reusable Workflow を分けて配布する」構成が、そのままジョブ本数に直結している。

| リポジトリ | 現状のジョブ数（PR への push 1 回あたり） |
|---|---|
| visual-caret-move | 4 |
| dilemma-procyon | 3〜4 |
| secure-sync / air-innovate-site | 3 |
| その他 12 リポジトリ | 2 |

## 決定の要点

1. **ShellCheck を Reusable Workflow から composite action へ移す**
   Reusable Workflow（`jobs.<job_id>.uses`）は必ず独立ジョブになる。1 ジョブに `uses` は 1 つしか書けず `steps` とも併用できないため、複数の Reusable を 1 ジョブにまとめることは構造上できない。composite action（`steps.uses`）なら呼び出し元ジョブの中で動く
2. **各リポジトリの検証を `name: CI` の単一ワークフロー・単一ジョブへ集約する**
   `Rust CI` / `Test` / `PR ビルド検証` 等をステップとして統合する
3. **配布する `ci.yml` のダミー（`run: true`）を実検証にする**
4. **`push: main` を CI から外す**（release-please 系と E2E NextCloud は除外）
5. **`runs-on` は検証内容で選ぶ**（ShellCheck だけなら `ubuntu-slim`）
6. **ガバナンスは `repos ci check` で担保する**
   `ci.yml` は実検証を含むためリポジトリ固有になり、配布では維持できない
7. **composite action の命名規約を追加する**（`actions/<用途名>/action.yml` + `docs/actions/<用途名>.md`）

## 実測で判明した無駄

- **`.sh` を 1 つも持たない 7 リポジトリで ShellCheck が走っている。** ai-chat-platform、ai-quota-hud、bright-moon-shingetsu、bright-moon-site、misa-player、my-life、win-dev-bootstrap。`find` して 0 件で即終了するだけのジョブに**月 153 分**
- **`.sh` を持つリポジトリでも変更は稀。** 2026-07 の PR 496 件のうち `.sh` を含むのは 60 件（12%）
- **`sudo apt-get install shellcheck` は死んだコード。** `ubuntu-latest`（0.9.0）、`ubuntu-26.04`（0.11.0）、`ubuntu-slim`（0.9.0）すべてに同梱済み。しかも `ubuntu-slim` の非特権コンテナでは失敗する

## 見込み

| 段階 | 課金 |
|---|---|
| 現状 | 2,721 分 |
| 検証系を 1 ジョブへ統合 | 1,869 分 |
| `push: main` を削除 | 1,485 分 |
| Label Sync の起動抑制（対応済み） | 1,255 分 |

## 失うもの

- ジョブ単位の切り分け（ShellCheck の失敗とテストの失敗が同じジョブに並ぶ）
- 並列実行（実処理が 2 分未満のため実害は小さい）
- `ci.yml` の配布による維持（`repos ci check` による検査が前提になる）

## 検討して採用しなかった案

- `shellcheck.yml` への path フィルタ追加（月 323 分。composite action 化の 367 分を下回り、独立ワークフロー構成が固定される。#59 はこの案）
- ShellCheck を各リポジトリへ直接コピー（ADR 0001 で解決した「修正が届かない」問題が再発する）
- 軽い検証だけ別ジョブで `ubuntu-slim`（ジョブを分けた時点で切り上げが増え、統合より常に高い）
- `ci.yml` を完全配布可能にし固有検証を `scripts/ci.sh` へ寄せる（mise / bun / cargo / uv のセットアップとキャッシュが action 依存のため、キャッシュを失う）

## 移行

一度に全リポジトリへ適用しない。`repos apply` は 16 リポジトリ分の PR と CI（約 64 分）を伴うため、テンプレート変更をまとめて 1 回で行う。利用頻度の高いリポジトリから個別 PR で統合し、残りは翌月の配布でまとめる。

## 確認

- `scripts/check-workflow-templates.sh` 合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)