### PR TITLE
docs: 標準CIのランナー選択理由を記載する

### DIFF
--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ permissions:
 
 jobs:
   ci:
+    # 軽量ジョブのため ubuntu-slim を使用。
+    # 実行時間が継続的に 1 分を超える場合は ubuntu-latest への変更を検討する。
     runs-on: ubuntu-slim
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## 概要

標準 CI テンプレートで `ubuntu-slim` を選択している理由をコメントとして明記する。

## 変更内容

- 軽量ジョブのため `ubuntu-slim` を使用することを記載
- 実行時間が継続的に 1 分を超える場合の見直し条件を記載

## 確認

- `scripts/sync-workflow-callers.sh --write`
- `scripts/check-workflow-templates.sh`
- `git diff --check`