### PR TITLE
feat: Issueに共通Risk分類を追加する

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -37,6 +37,17 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: risk
+    attributes:
+      label: リスク
+      options:
+        - normal
+        - high
+      default: 0
+    validations:
+      required: true
+
   - type: textarea
     id: summary
     attributes:

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -37,6 +37,17 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: risk
+    attributes:
+      label: リスク
+      options:
+        - normal
+        - high
+      default: 0
+    validations:
+      required: true
+
   - type: textarea
     id: summary
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -37,6 +37,17 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: risk
+    attributes:
+      label: リスク
+      options:
+        - normal
+        - high
+      default: 0
+    validations:
+      required: true
+
   - type: textarea
     id: summary
     attributes:

--- a/.github/ISSUE_TEMPLATE/improvement.yml
+++ b/.github/ISSUE_TEMPLATE/improvement.yml
@@ -37,6 +37,17 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: risk
+    attributes:
+      label: リスク
+      options:
+        - normal
+        - high
+      default: 0
+    validations:
+      required: true
+
   - type: textarea
     id: summary
     attributes:

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -37,6 +37,17 @@ body:
     validations:
       required: true
 
+  - type: dropdown
+    id: risk
+    attributes:
+      label: リスク
+      options:
+        - normal
+        - high
+      default: 0
+    validations:
+      required: true
+
   - type: textarea
     id: summary
     attributes:

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -40,6 +40,11 @@
   color: "bfd4f2"
   description: "依存先の open Issue などがあり、patrol では今は後回しにする"
 
+# risk ラベル
+- name: risk-high
+  color: "e11d48"
+  description: "高リスク。AIエージェントのルーティングで注意が必要"
+
 # status ラベル
 - name: duplicate
   color: "cfd3d7"

--- a/.github/workflows/triage-reusable.yml
+++ b/.github/workflows/triage-reusable.yml
@@ -112,6 +112,7 @@ jobs:
 
           priority_opt="$(extract_first_line_under_heading "優先度")"
           size_opt="$(extract_first_line_under_heading "Size")"
+          risk_opt="$(extract_first_line_under_heading "リスク")"
 
           # 簡易正規化（Issue Form のフル表記「P1: 高」等も短縮表記も、
           # Project の選択肢名である P0〜P3 に正規化する）
@@ -126,6 +127,16 @@ jobs:
           case "${size_opt^^}" in
             XS|S|M|L|XL) size_opt="${size_opt^^}" ;;
           esac
+
+          # risk-high ラベルの付与・除去（GITHUB_TOKEN のみで実行できるため PROJECT_TOKEN 確認より前に処理する）
+          # ### リスク 見出しが無い既存 Issue や risk=normal の場合はラベルを除去する（冪等）
+          if [[ "${risk_opt,,}" == "high" ]]; then
+            GH_TOKEN="${GITHUB_TOKEN}" gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/labels" \
+              -X POST -f "labels[]=risk-high" >/dev/null 2>&1 || true
+          else
+            GH_TOKEN="${GITHUB_TOKEN}" gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/labels/risk-high" \
+              -X DELETE >/dev/null 2>&1 || true
+          fi
 
           if [[ -z "${PROJECT_TOKEN:-}" ]]; then
             comment "Projects v2 を更新するためのトークンが未設定です。PROJECT_TOKEN（Project への書き込み権限）を設定してください。\n\n- 取得値: 優先度=${priority_opt}, Size=${size_opt}\n\nIssue: ${issue_url}"

--- a/.github/workflows/triage-reusable.yml
+++ b/.github/workflows/triage-reusable.yml
@@ -131,8 +131,12 @@ jobs:
           # risk-high ラベルの付与・除去（GITHUB_TOKEN のみで実行できるため PROJECT_TOKEN 確認より前に処理する）
           # ### リスク 見出しが無い既存 Issue や risk=normal の場合はラベルを除去する（冪等）
           if [[ "${risk_opt,,}" == "high" ]]; then
-            GH_TOKEN="${GITHUB_TOKEN}" gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/labels" \
-              -X POST -f "labels[]=risk-high" >/dev/null 2>&1 || true
+            # 配布先で Label Sync が未実行だと risk-high ラベルが存在せず失敗する。
+            # 黙って握り潰すとルーティングに必要な分類が付かないままになるため、コメントで知らせる。
+            if ! GH_TOKEN="${GITHUB_TOKEN}" gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/labels" \
+              -X POST -f "labels[]=risk-high" >/dev/null 2>&1; then
+              comment "risk-high ラベルを付与できませんでした。リポジトリに risk-high ラベルが存在するか（Label Sync 実行済みか）確認してください。\n\nIssue: ${issue_url}"
+            fi
           else
             GH_TOKEN="${GITHUB_TOKEN}" gh api "repos/${REPO}/issues/${ISSUE_NUMBER}/labels/risk-high" \
               -X DELETE >/dev/null 2>&1 || true

--- a/docs/reusable-workflows/triage.md
+++ b/docs/reusable-workflows/triage.md
@@ -30,7 +30,7 @@ CLI で `--body` を直接指定して起票する場合は Issue Forms を経�
   なる（例: `### 優先度` の次の行に選択値が入る）
 
 対象ファイル: `bug.yml` / `feature.yml` / `improvement.yml` / `task.yml` /
-`documentation.yml`。5 種類とも `優先度` / `Size` の見出し名・選択肢は統一されている。
+`documentation.yml`。5 種類とも `優先度` / `Size` / `リスク` の見出し名・選択肢は統一されている。
 
 ## Triage workflow（`triage.yml` → `triage-reusable.yml`）の役割
 
@@ -42,7 +42,7 @@ CLI で `--body` を直接指定して起票する場合は Issue Forms を経�
   - `edited` は残す。本文の `### 優先度` / `### Size` を後から直したときに
     Project へ反映する必要があるため
 - 処理:
-  1. Issue 本文から `### 優先度` / `### Size` 見出し直下の最初の非空行を抽出する
+  1. Issue 本文から `### 優先度` / `### Size` / `### リスク` 見出し直下の最初の非空行を抽出する
   2. `優先度` は `P0`〜`P3` で始まる値（Issue Form のフル表記 `P0: 緊急` や
      短縮表記 `P0` のいずれでも可）を、Project の実際の選択肢名である
      `P0`〜`P3` に正規化する。`未定` はそのまま扱う（Project 側に対応する
@@ -50,9 +50,13 @@ CLI で `--body` を直接指定して起票する場合は Issue Forms を経�
      `未定` を削除済みだが、削除前に起票された既存 Issue の本文には残るため、
      workflow 側の扱いは変更していない
   3. `Size` は大文字に正規化する（`m` → `M`）
-  4. Project（`project_number` input、既定 12）に Issue を追加する
+  4. `リスク` が `high`（大文字小文字を問わない）の場合は `risk-high` ラベルを付与する。
+     `高リスク` を `normal` に戻した場合（`edited` イベント）はラベルを除去する。
+     `### リスク` 見出しが存在しない既存 Issue は `normal` として扱い、ラベルを除去する。
+     この処理は `GITHUB_TOKEN`（`issues: write`）のみで完了し、`PROJECT_TOKEN` は不要。
+  5. Project（`project_number` input、既定 12）に Issue を追加する
      - 既に Project に追加済みの item があればそれを再利用し、二重追加はしない
-  5. Project の `Priority` / `Size` フィールド（Single select）に、正規化できた値**だけ**を
+  6. Project の `Priority` / `Size` フィールド（Single select）に、正規化できた値**だけ**を
      独立して設定する。優先度/Size は互いに独立に扱い、片方しか取得できない場合
      （見出しが無い・値が空・選択肢に一致しない・フィールド名が不一致など）でも、
      もう片方が取得できていればそちらだけは設定する
@@ -67,8 +71,8 @@ CLI で `--body` を直接指定して起票する場合は Issue Forms を経�
      - Issue Form の dropdown 表示テキスト（`P0: 緊急` 等）はあくまで Issue 本文
        上の表記であり、Project 側の選択肢名とは異なる。混同しないこと
 - 失敗時の挙動: **ハード失敗せず、Issue にフォールバックコメントを付けて
-  `exit 0` で正常終了する。** Project への追加（4.）は優先度/Size の取得成否に
-  関係なく独立して実行する。優先度/Size のフィールド更新（5.）は互いに独立で、
+  `exit 0` で正常終了する。** Project への追加（5.）は優先度/Size の取得成否に
+  関係なく独立して実行する。優先度/Size のフィールド更新（6.）は互いに独立で、
   一方が設定できない事情があってももう一方は設定を試みる。
   想定される失敗パターンと対応するコメント:
   - `PROJECT_TOKEN` シークレット未設定 → 「トークンが未設定です」
@@ -111,7 +115,8 @@ projects（Project への追加）は Triage workflow が担うため、呼び�
   の実行や `project` OAuth scope の確認を行う必要はない
 - 本文: `### 優先度` と `### Size` の見出しを、Issue Forms と同じ表記
   （`P0: 緊急`〜`P3: 低` / `XS`〜`XL`、または `P0`〜`P3` の短縮形）で
-  含める。見出し名・選択値の表記が変わると Triage workflow が値を抽出できず、
+  含める。高リスク Issue の場合は `### リスク` 見出しの下に `high` を含める。
+  見出し名・選択値の表記が変わると Triage workflow が値を抽出できず、
   フォールバックコメントが付くだけで Project フィールドは更新されない
 
 Triage workflow は、この本文フォーマットが守られている前提で

--- a/docs/reusable-workflows/triage.md
+++ b/docs/reusable-workflows/triage.md
@@ -53,7 +53,12 @@ CLI で `--body` を直接指定して起票する場合は Issue Forms を経�
   4. `リスク` が `high`（大文字小文字を問わない）の場合は `risk-high` ラベルを付与する。
      `高リスク` を `normal` に戻した場合（`edited` イベント）はラベルを除去する。
      `### リスク` 見出しが存在しない既存 Issue は `normal` として扱い、ラベルを除去する。
-     この処理は `GITHUB_TOKEN`（`issues: write`）のみで完了し、`PROJECT_TOKEN` は不要。
+     この処理は `GITHUB_TOKEN`（`issues: write`）のみで完了し、`PROJECT_TOKEN` は不要
+     - **前提として配布先に `risk-high` ラベルが存在している必要がある。** ラベル定義の
+       正本は `.github/labels.yml` で、配布先へは Label Sync（`workflow_dispatch`）で
+       反映される。`labels.yml` へ `risk-high` を追加した変更を `main` にマージした後、
+       全配布先で Label Sync を実行する。未実行のリポジトリではラベル付与が失敗し、
+       後述のフォールバックコメントが付く
   5. Project（`project_number` input、既定 12）に Issue を追加する
      - 既に Project に追加済みの item があればそれを再利用し、二重追加はしない
   6. Project の `Priority` / `Size` フィールド（Single select）に、正規化できた値**だけ**を
@@ -75,6 +80,8 @@ CLI で `--body` を直接指定して起票する場合は Issue Forms を経�
   関係なく独立して実行する。優先度/Size のフィールド更新（6.）は互いに独立で、
   一方が設定できない事情があってももう一方は設定を試みる。
   想定される失敗パターンと対応するコメント:
+  - `risk-high` ラベル付与の API 呼び出し失敗（配布先で Label Sync 未実行など）
+    → 「risk-high ラベルを付与できませんでした」
   - `PROJECT_TOKEN` シークレット未設定 → 「トークンが未設定です」
   - Project 取得失敗（owner/number 不一致） → 「Project の取得に失敗しました」
   - Project 追加の API 呼び出し失敗（権限不足など） → 「Project に追加できませんでした」


### PR DESCRIPTION
## 概要

Issue #68 の対応。AIエージェントのルーティング安全ルールへ入力できるよう、共通 `risk-high` ラベルと Issue Form へのリスク入力を最小差分で追加する。

- `labels.yml` に `risk-high` ラベルを追加する（label-sync の strict sync に含まれるため全リポジトリへ自動配布される）
- 全 Issue Form 5 種（bug / feature / task / improvement / documentation）にリスク dropdown を統一追加する（`normal` / `high`、既定: `normal`）
- `triage-reusable.yml` で `### リスク` 見出しを抽出し、`high` のときに `risk-high` ラベルを付与、それ以外はラベルを除去する（`edited` イベントで high → normal への変更も反映）
- `docs/reusable-workflows/triage.md` を新仕様に合わせて更新する

## 受け入れ条件の確認

- [x] 高リスク Issue を機械的に識別できる（`risk-high` ラベルが triage で自動付与）
- [x] Risk 未指定の既存 Issue と既存 repo を壊さない（`### リスク` 見出しなし → ラベル除去を試みるが `|| true` で無視）
- [x] 共通ラベルの strict sync に含まれる（`labels.yml` 追加 + `delete-other-labels: true`）
- [x] Issue Form 間で Risk 表現が統一される（5 種で同一 dropdown）
- [x] routing 実装からモデル名に依存せず参照できる（`risk-high` ラベル名はモデル名を含まない）

## 検証

- [x] ShellCheck（追加コードに新規エラーなし）
- [x] `bash -n`（シェル構文エラーなし）
- [x] `sync-workflow-callers.sh --check`（templates/ と差分なし）
- [x] pre-commit hook（workflow template check 通過）
- [ ] 実 GitHub Actions でのラベル付与動作（ローカルでは検証不可）

Closes #68