### PR TITLE
docs: CI標準テンプレートのコメントをAuto-merge要件から独立させる

### DIFF
--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -1,15 +1,14 @@
-# CI が未整備のリポジトリ用の標準 workflow。
-# 既に name: CI を持つ workflow がある場合は配布しない。
+# このリポジトリの標準 CI。PR ごとに実行する検証をこの workflow にまとめる。
+# 現在の中身は ShellCheck だけなので、必要な検証は steps に追加してよい。
+# 不要な step は外してよい。
 #
-# name: CI は変更しないこと。Dependabot Auto-merge は workflow_run で
-# 「CI」という名前の workflow の完了を発火トリガーにしている。中身は問わない。
-# マージ可否は発火後にそのSHA上の全チェック（Actions workflow run・外部CIの
-# check run・commit status）を別途確認して決まる仕組みで、CI自身の中身が
-# gate になっているわけではない。
-#
-# 現状の実処理は ShellCheck のみだが、これは現時点の中身であって上記の
-# トリガー要件とは独立している。ShellCheck が不要なリポジトリでは、
-# name: CI を保ったまま中身だけ入れ替えてよい。
+# 初期テンプレートは hasegawa496/.github の templates/.github/workflows/ci.yml。
+# 配布は name: CI を持つ workflow がないリポジトリへの初回のみで、
+# 以後このファイルが上書きされることはない。
+
+# name は変更しない。Dependabot Auto-merge が「CI」という名前の workflow の
+# 完了を発火トリガーにしているため、改名すると自動マージが動かなくなる。
+# マージ可否は発火後の全チェック確認で決まるので、中身の入れ替えは自由でよい。
 name: CI
 
 on:

--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -1,7 +1,15 @@
 # CI が未整備のリポジトリ用の標準 workflow。
 # 既に name: CI を持つ workflow がある場合は配布しない。
-# 最低限 ShellCheck を実行しつつ、Dependabot Auto-merge の workflow_run を
-# 必ず発火させるトリガーも兼ねる（docs/reusable-workflows/ci.md）。
+#
+# name: CI は変更しないこと。Dependabot Auto-merge は workflow_run で
+# 「CI」という名前の workflow の完了を発火トリガーにしている。中身は問わない。
+# マージ可否は発火後にそのSHA上の全チェック（Actions workflow run・外部CIの
+# check run・commit status）を別途確認して決まる仕組みで、CI自身の中身が
+# gate になっているわけではない。
+#
+# 現状の実処理は ShellCheck のみだが、これは現時点の中身であって上記の
+# トリガー要件とは独立している。ShellCheck が不要なリポジトリでは、
+# name: CI を保ったまま中身だけ入れ替えてよい。
 name: CI
 
 on:


### PR DESCRIPTION
## 概要

`templates/.github/workflows/ci.yml` は配布先リポジトリにコピーされて置かれるファイルなので、コメントを配布先目線に書き直す。

旧コメントには次の2つの問題があった。

- 「配布しない」など配布元の運用ルールが書かれており、置かれた側には判断材料にならない
- 「最低限ShellCheckを実行しつつ、Auto-mergeのトリガーも兼ねる」という書き方が、ShellCheckの実処理と`name: CI`の発火要件を一体であるかのように読ませた
- この誤解により、`.sh`の無いリポジトリでもAuto-mergeの発火に支障が出るという理由でShellCheckを残す誤判断が実際に発生した

## 変更内容

- ヘッダは workflow そのものの説明にする（何をする workflow か、検証を足し引きしてよいか、このファイルが上書きされるか）
- `name: CI` を変更してはいけないという制約と、その理由（Auto-mergeの発火トリガー）は `name` の直上へ移す
- ShellCheck は現在の中身の一例に過ぎず、`name` の制約とは独立していることがコメントの配置から読み取れるようにする

## 検証

- `scripts/check-workflow-templates.sh` 合格
- `scripts/sync-workflow-callers.sh --write` 実行（自リポジトリの `ci.yml` は `name: CI` 保持のため対象外で差分なし）

Closes #70