### PR TITLE
chore: hk 共通フック設定の配布ベースモジュール Shared.pkl を追加する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@
 - `.github/workflows/*-reusable.yml`（Reusable Workflow）
 - `actions/*/action.yml`（composite action）
 - `templates/.github/**`（配布テンプレ）
+- `hk/Shared.pkl`（hk 共通フック設定。配布専用のベースモジュールで、各管理対象リポジトリの `hk.pkl` から `amends` でリモート参照される）
 - `scripts/sync-workflow-callers.sh` と `scripts/check-workflow-templates.sh`
 - `docs/github-workflow-operations.md`
 - `docs/reusable-workflows.md`

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@
   - `actions/shellcheck/action.yml`
 - 配布テンプレート
   - `templates/.github/**`
+- hk 共通フック設定
+  - `hk/Shared.pkl`
+  - 配布専用のベースモジュール。`templates/.github/**` のように配布先へコピーされるのではなく、各管理対象リポジトリの `hk.pkl` から `amends` でリモート参照される
+  - `main` へのマージが即座に全リポジトリへ波及するため、内容は言語非依存の共通ルールに限定する
 - 自己利用の同期・検証スクリプト
   - `scripts/sync-workflow-callers.sh`
   - `scripts/check-workflow-templates.sh`

--- a/hk/Shared.pkl
+++ b/hk/Shared.pkl
@@ -1,0 +1,29 @@
+amends "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Config.pkl"
+import "package://github.com/jdx/hk/releases/download/v1.54.0/hk@1.54.0#/Builtins.pkl"
+
+local linters = new Mapping<String, Step> {
+    ["actionlint"] = Builtins.actionlint
+    ["check_added_large_files"] = Builtins.check_added_large_files
+    ["check_merge_conflict"] = Builtins.check_merge_conflict
+    ["detect_private_key"] = Builtins.detect_private_key
+    ["gitleaks"] = Builtins.gitleaks
+    ["shellcheck"] = Builtins.shellcheck
+    ["shfmt"] = Builtins.shfmt
+    ["typos"] = Builtins.typos
+    ["yamllint"] = Builtins.yamllint
+}
+
+hooks {
+    ["pre-commit"] {
+        fix = true
+        stash = "git"
+        steps = linters
+    }
+    ["fix"] {
+        fix = true
+        steps = linters
+    }
+    ["check"] {
+        steps = linters
+    }
+}


### PR DESCRIPTION
## 概要

- 管理対象リポジトリ間で hk（git hooks manager）の言語非依存 builtins・hooks 定義を共有する基点として `hk/Shared.pkl` を追加する
- 各管理対象リポジトリの `hk.pkl` は `amends "https://raw.githubusercontent.com/hasegawa496/.github/refs/heads/main/hk/Shared.pkl"` の形で `main` の HEAD を直接参照する想定（設計は `hasegawa496/repo-ops#147` で確定済み）
- `README.md` / `AGENTS.md` に `hk/Shared.pkl` が配布専用のベースモジュールであることを追記する

## 変更内容

- `hk/Shared.pkl`（新規）: 現行 `hasegawa496/repo-ops/templates/hooks/hk.pkl` と同内容（9 builtins + `pre-commit`/`fix`/`check` hooks）
- `README.md`: 「このリポジトリで管理するもの」に `hk/Shared.pkl` の位置づけを追記
- `AGENTS.md`: 「管理対象」リストに `hk/Shared.pkl` を追記

## スコープ外（申し送り）

- 本リポジトリ自身が使う `hk.pkl`（root）は本 Issue のスコープに含めない。Issue コメントの決定どおり、`Shared.pkl` 完成後に `repos apply` の配布フローが用意する
- 各管理対象リポジトリへの amends 方式への追従展開は別 Issue（`hasegawa496/repo-ops#149` 等）で対応する

## テスト

- [x] `hk validate`（`hk/Shared.pkl` を一時的に `hk.pkl` として配置し検証、`hk /tmp/.../hk.pkl is valid`）
- [x] `scripts/check-workflow-templates.sh`（既存の配布テンプレート検証に影響がないことを確認）

Closes #73