### PR TITLE
feat: 標準hk設定にmainへの直接push防止hookを追加する

### DIFF
--- a/hk/Shared.pkl
+++ b/hk/Shared.pkl
@@ -28,7 +28,9 @@ hooks {
     }
     ["pre-push"] {
         steps {
-            ["no_commit_to_branch"] = Builtins.no_commit_to_branch
+            ["no_push_to_protected_branch"] = new Step {
+                check = "! printf '%s' \"{{ hook_stdin }}\" | awk '{print $3}' | grep -qE '^refs/heads/(main|master)$'"
+            }
         }
     }
 }

--- a/hk/Shared.pkl
+++ b/hk/Shared.pkl
@@ -29,7 +29,8 @@ hooks {
     ["pre-push"] {
         steps {
             ["no_push_to_protected_branch"] = new Step {
-                check = "! printf '%s' \"{{ hook_stdin }}\" | awk '{print $3}' | grep -qE '^refs/heads/(main|master)$'"
+                stdin = "{{ hook_stdin }}"
+                check = "! awk '{print $3}' | grep -qE '^refs/heads/(main|master)$'"
             }
         }
     }

--- a/hk/Shared.pkl
+++ b/hk/Shared.pkl
@@ -26,4 +26,9 @@ hooks {
     ["check"] {
         steps = linters
     }
+    ["pre-push"] {
+        steps {
+            ["no_commit_to_branch"] = Builtins.no_commit_to_branch
+        }
+    }
 }


### PR DESCRIPTION
## 概要

- `hk/Shared.pkl` に `hooks["pre-push"]` を新設し、`Builtins.no_commit_to_branch` を steps に登録した。
- main/master ブランチを checkout した状態での `git push` をクライアントサイドでブロックする（`HK=0` / `--no-verify` 等での回避は許容する既定仕様）。
- 既存の `pre-commit` / `fix` / `check` が共有する `linters` には含めず、push 専用の hook として分離した（スコープ外の拡張を避けるため）。

## 設計根拠

Issue #74 のコメントに設計分析を記録済み。

- hk 1.54.0 に push 拒否専用の builtin は無く、現在の checkout ブランチのみを見る `no_commit_to_branch` が pre-push でも意味を持つことを確認した。
- 実機で `hk validate` / `hk run pre-push` を実行し、main では exit 1（ブロック）、feature ブランチでは exit 0（通過）を確認した。

Closes #74

## テスト

- [x] `hk validate`（Shared.pkl を amends する一時 hk.pkl 経由）
- [x] `hk run pre-push`: main ブランチでブロックされることを確認
- [x] `hk run pre-push`: feature ブランチで通過することを確認
- [ ] マージ後のローカル hk キャッシュクリア（`hk-shared-config-update` Skill の手順4）は本 PR のマージ後にフォローアップとして実施する