### PR TITLE
fix: gitleaksをgit --stagedスキャンに切り替えディレクトリ全体誤検知を防ぐ

### DIFF
--- a/hk/Shared.pkl
+++ b/hk/Shared.pkl
@@ -6,7 +6,15 @@ local linters = new Mapping<String, Step> {
     ["check_added_large_files"] = Builtins.check_added_large_files
     ["check_merge_conflict"] = Builtins.check_merge_conflict
     ["detect_private_key"] = Builtins.detect_private_key
-    ["gitleaks"] = Builtins.gitleaks
+    ["gitleaks"] = new Step {
+        // Builtins.gitleaks は `gitleaks dir --redact --verbose --no-banner {{ files }}` を使うが、
+        // `gitleaks dir` はディレクトリ引数を1つしか受け付けない。ステージ済みファイルが複数あると
+        // hk が {{ files }} に複数パスを展開してしまい、意図せずリポジトリ全体（.gitignore対象を含む）
+        // を走査して無関係な既存ファイルの誤検知を大量に出す。`git --staged` はステージ済み差分だけを
+        // 対象にするため、この問題が起きない。
+        types = List("text")
+        check = "gitleaks git --staged --redact --verbose --no-banner"
+    }
     ["shellcheck"] = Builtins.shellcheck
     ["shfmt"] = Builtins.shfmt
     ["typos"] = Builtins.typos

--- a/hk/Shared.pkl
+++ b/hk/Shared.pkl
@@ -40,6 +40,14 @@ local linters = new Mapping<String, Step> {
 // 空入力時に無引数実行しないためのガードは、対象ファイルの有無を
 // （キューティング有無に関わらず出力が空かどうかだけを見る）非NULモードの
 // `git ls-files` で判定してから、実際の走査だけを `-z` 経路で行う。
+// `[ -e ]` ではなく `[ -f ]` で現存チェックする。`git ls-files --cached` は
+// submodule の gitlink パス（index mode 160000）も列挙し、そのパスは作業ツリー上では
+// ディレクトリとして存在する。`-e` は真になり、`gitleaks dir` にディレクトリを渡すと
+// そのsubmodule配下（親リポジトリの管理外）を丸ごと再帰走査してしまう。`-f` は通常
+// ファイルにしか真にならないため、submodule のディレクトリを自然に除外できる。
+// `gitleaks dir` へのパスはオプション終端 `--` の後に渡す。`--` が無いと、
+// `--exit-code=0` のような対象パスをgitleaksがオプションとして解釈し、
+// 挙動（この例では漏洩検出時の終了コード）が意図せず変わりうる。
 local gitleaksPreCommit = new Step {
     types = List("text")
     check = "gitleaks git --staged --redact --verbose --no-banner"
@@ -48,7 +56,7 @@ local gitleaksPreCommit = new Step {
 local gitleaksFullScan = new Step {
     types = List("text")
     check = #"""
-        gitleaks git --redact --verbose --no-banner && { [ -z "$(git ls-files --cached --others --exclude-standard)" ] || git ls-files -z --cached --others --exclude-standard | xargs -0 -n1 -- sh -c 'f="$1"; [ -e "$f" ] || exit 0; gitleaks dir --redact --verbose --no-banner "$f"' _; }
+        gitleaks git --redact --verbose --no-banner && { [ -z "$(git ls-files --cached --others --exclude-standard)" ] || git ls-files -z --cached --others --exclude-standard | xargs -0 -n1 -- sh -c 'f="$1"; [ -f "$f" ] || exit 0; gitleaks dir --redact --verbose --no-banner -- "$f"' _; }
         """#
 }
 

--- a/hk/Shared.pkl
+++ b/hk/Shared.pkl
@@ -16,19 +16,21 @@ local linters = new Mapping<String, Step> {
 // `gitleaks dir` はディレクトリ引数を1つしか受け付けない。対象ファイルが複数あると
 // hk が {{ files }} に複数パスを展開してしまい、意図せずリポジトリ全体（.gitignore対象を含む）
 // を走査して無関係な既存ファイルの誤検知を大量に出す。
-// pre-commit はステージ済み差分だけを見れば十分なので `git --staged` を使うが、
-// `check`/`fix` は checkout 済みの全ファイルを検査する必要があり、ステージが空（クリーンな
-// checkout 上のCI実行など）だと `--staged` は何も検査せず成功してしまう。
-// `check`/`fix` 側は git 管理下の全履歴を対象にする `gitleaks git`（引数無し）を使うことで、
-// 対象ファイル数に関わらず単一コマンドで完結し、.gitignore対象も含めない。
+// pre-commit はステージ済み差分だけを見れば十分なので `git --staged` を使う。
+// `check`/`fix` は次の2系統を両方満たす必要がある。
+//   1. 過去にコミット済みの漏洩（`gitleaks git`、コミット履歴を対象）
+//   2. 作業ツリー上の未コミット・未追跡ファイルの漏洩（コミット履歴には現れない）
+// 2 を `gitleaks dir` 1回で行うと元の複数引数バグに戻るため、`git ls-files` で
+// 対象ファイル（追跡済み + 追跡対象外だが .gitignore 対象でもないファイル）を列挙し、
+// ファイルごとに `gitleaks dir` を1引数で呼び出す。
 local gitleaksPreCommit = new Step {
     types = List("text")
     check = "gitleaks git --staged --redact --verbose --no-banner"
 }
 
-local gitleaksFullHistory = new Step {
+local gitleaksFullScan = new Step {
     types = List("text")
-    check = "gitleaks git --redact --verbose --no-banner"
+    check = "gitleaks git --redact --verbose --no-banner && git ls-files -z --cached --others --exclude-standard | xargs -0 -r -n1 gitleaks dir --redact --verbose --no-banner"
 }
 
 hooks {
@@ -48,7 +50,7 @@ hooks {
             for (name, step in linters) {
                 [name] = step
             }
-            ["gitleaks"] = gitleaksFullHistory
+            ["gitleaks"] = gitleaksFullScan
         }
     }
     ["check"] {
@@ -56,7 +58,7 @@ hooks {
             for (name, step in linters) {
                 [name] = step
             }
-            ["gitleaks"] = gitleaksFullHistory
+            ["gitleaks"] = gitleaksFullScan
         }
     }
     ["pre-push"] {

--- a/hk/Shared.pkl
+++ b/hk/Shared.pkl
@@ -31,11 +31,15 @@ local linters = new Mapping<String, Step> {
 // （かつ未ステージ）のファイルも含まれる。存在しないパスを `gitleaks dir` に渡すと
 // エラー終了するため、ループ内で現存チェックしてスキップする。
 // `git ls-files` は core.quotePath（既定 true）により、日本語等の非ASCII文字を含む
-// パスを `"\346..."` のような引用符付き8進エスケープで出力する。改行区切りで
-// そのまま `read` すると引用符付き文字列がそのまま変数に入り、実在チェックが
-// 常に失敗して該当ファイルが黙ってスキップされる。`-z`（NUL区切り、常に非エスケープの
-// 生パスを出力）を使い、`read -d` が使えないPOSIX sh（dash等）でも動くよう
-// `tr '\0' '\n'` で改行区切りへ変換してから読む。
+// パスを `"\346..."` のような引用符付き8進エスケープで出力するため、`-z`（NUL区切り、
+// 常に非エスケープの生パスを出力）を使う。NUL区切りを改行区切りへ変換すると、
+// 万一パス自体に改行が含まれる場合に同じ問題が再発するため変換しない。
+// `xargs -0` はNULを直接扱え、かつ `-r`（`--no-run-if-empty`）と異なりGNU/BSD双方の
+// 実装にあるため使う。`xargs -0 -n1 -- sh -c '...' _` の形で1パスずつ実引数として
+// 渡す（`-I` によるテキスト置換はパス中の引用符等でコマンドが壊れうるため使わない）。
+// 空入力時に無引数実行しないためのガードは、対象ファイルの有無を
+// （キューティング有無に関わらず出力が空かどうかだけを見る）非NULモードの
+// `git ls-files` で判定してから、実際の走査だけを `-z` 経路で行う。
 local gitleaksPreCommit = new Step {
     types = List("text")
     check = "gitleaks git --staged --redact --verbose --no-banner"
@@ -44,7 +48,7 @@ local gitleaksPreCommit = new Step {
 local gitleaksFullScan = new Step {
     types = List("text")
     check = #"""
-        gitleaks git --redact --verbose --no-banner && git ls-files -z --cached --others --exclude-standard | tr '\0' '\n' | { status=0; while IFS= read -r f; do [ -e "$f" ] || continue; gitleaks dir --redact --verbose --no-banner "$f" || status=1; done; exit $status; }
+        gitleaks git --redact --verbose --no-banner && { [ -z "$(git ls-files --cached --others --exclude-standard)" ] || git ls-files -z --cached --others --exclude-standard | xargs -0 -n1 -- sh -c 'f="$1"; [ -e "$f" ] || exit 0; gitleaks dir --redact --verbose --no-banner "$f"' _; }
         """#
 }
 

--- a/hk/Shared.pkl
+++ b/hk/Shared.pkl
@@ -27,6 +27,9 @@ local linters = new Mapping<String, Step> {
 // `-r`（`--no-run-if-empty`）は macOS 等の BSD 版 `xargs` に存在しないため使わない。
 // 代わりに `while read` ループで1ファイルずつ処理し、対象ファイルが0件なら
 // ループ自体が実行されないことで同じ効果（無引数呼び出しをしない）を得る。
+// `git ls-files --cached` は index 上のパスを列挙するため、作業ツリーから削除済み
+// （かつ未ステージ）のファイルも含まれる。存在しないパスを `gitleaks dir` に渡すと
+// エラー終了するため、ループ内で現存チェックしてスキップする。
 local gitleaksPreCommit = new Step {
     types = List("text")
     check = "gitleaks git --staged --redact --verbose --no-banner"
@@ -35,7 +38,7 @@ local gitleaksPreCommit = new Step {
 local gitleaksFullScan = new Step {
     types = List("text")
     check = #"""
-        gitleaks git --redact --verbose --no-banner && git ls-files --cached --others --exclude-standard | { status=0; while IFS= read -r f; do gitleaks dir --redact --verbose --no-banner "$f" || status=1; done; exit $status; }
+        gitleaks git --redact --verbose --no-banner && git ls-files --cached --others --exclude-standard | { status=0; while IFS= read -r f; do [ -e "$f" ] || continue; gitleaks dir --redact --verbose --no-banner "$f" || status=1; done; exit $status; }
         """#
 }
 

--- a/hk/Shared.pkl
+++ b/hk/Shared.pkl
@@ -6,33 +6,58 @@ local linters = new Mapping<String, Step> {
     ["check_added_large_files"] = Builtins.check_added_large_files
     ["check_merge_conflict"] = Builtins.check_merge_conflict
     ["detect_private_key"] = Builtins.detect_private_key
-    ["gitleaks"] = new Step {
-        // Builtins.gitleaks は `gitleaks dir --redact --verbose --no-banner {{ files }}` を使うが、
-        // `gitleaks dir` はディレクトリ引数を1つしか受け付けない。ステージ済みファイルが複数あると
-        // hk が {{ files }} に複数パスを展開してしまい、意図せずリポジトリ全体（.gitignore対象を含む）
-        // を走査して無関係な既存ファイルの誤検知を大量に出す。`git --staged` はステージ済み差分だけを
-        // 対象にするため、この問題が起きない。
-        types = List("text")
-        check = "gitleaks git --staged --redact --verbose --no-banner"
-    }
     ["shellcheck"] = Builtins.shellcheck
     ["shfmt"] = Builtins.shfmt
     ["typos"] = Builtins.typos
     ["yamllint"] = Builtins.yamllint
 }
 
+// Builtins.gitleaks は `gitleaks dir --redact --verbose --no-banner {{ files }}` を使うが、
+// `gitleaks dir` はディレクトリ引数を1つしか受け付けない。対象ファイルが複数あると
+// hk が {{ files }} に複数パスを展開してしまい、意図せずリポジトリ全体（.gitignore対象を含む）
+// を走査して無関係な既存ファイルの誤検知を大量に出す。
+// pre-commit はステージ済み差分だけを見れば十分なので `git --staged` を使うが、
+// `check`/`fix` は checkout 済みの全ファイルを検査する必要があり、ステージが空（クリーンな
+// checkout 上のCI実行など）だと `--staged` は何も検査せず成功してしまう。
+// `check`/`fix` 側は git 管理下の全履歴を対象にする `gitleaks git`（引数無し）を使うことで、
+// 対象ファイル数に関わらず単一コマンドで完結し、.gitignore対象も含めない。
+local gitleaksPreCommit = new Step {
+    types = List("text")
+    check = "gitleaks git --staged --redact --verbose --no-banner"
+}
+
+local gitleaksFullHistory = new Step {
+    types = List("text")
+    check = "gitleaks git --redact --verbose --no-banner"
+}
+
 hooks {
     ["pre-commit"] {
         fix = true
         stash = "git"
-        steps = linters
+        steps {
+            for (name, step in linters) {
+                [name] = step
+            }
+            ["gitleaks"] = gitleaksPreCommit
+        }
     }
     ["fix"] {
         fix = true
-        steps = linters
+        steps {
+            for (name, step in linters) {
+                [name] = step
+            }
+            ["gitleaks"] = gitleaksFullHistory
+        }
     }
     ["check"] {
-        steps = linters
+        steps {
+            for (name, step in linters) {
+                [name] = step
+            }
+            ["gitleaks"] = gitleaksFullHistory
+        }
     }
     ["pre-push"] {
         steps {

--- a/hk/Shared.pkl
+++ b/hk/Shared.pkl
@@ -23,6 +23,10 @@ local linters = new Mapping<String, Step> {
 // 2 を `gitleaks dir` 1回で行うと元の複数引数バグに戻るため、`git ls-files` で
 // 対象ファイル（追跡済み + 追跡対象外だが .gitignore 対象でもないファイル）を列挙し、
 // ファイルごとに `gitleaks dir` を1引数で呼び出す。
+// hk のデフォルトシェルは `sh -o errexit -c`（POSIX sh）であり、GNU 版 `xargs` 固有の
+// `-r`（`--no-run-if-empty`）は macOS 等の BSD 版 `xargs` に存在しないため使わない。
+// 代わりに `while read` ループで1ファイルずつ処理し、対象ファイルが0件なら
+// ループ自体が実行されないことで同じ効果（無引数呼び出しをしない）を得る。
 local gitleaksPreCommit = new Step {
     types = List("text")
     check = "gitleaks git --staged --redact --verbose --no-banner"
@@ -30,7 +34,9 @@ local gitleaksPreCommit = new Step {
 
 local gitleaksFullScan = new Step {
     types = List("text")
-    check = "gitleaks git --redact --verbose --no-banner && git ls-files -z --cached --others --exclude-standard | xargs -0 -r -n1 gitleaks dir --redact --verbose --no-banner"
+    check = #"""
+        gitleaks git --redact --verbose --no-banner && git ls-files --cached --others --exclude-standard | { status=0; while IFS= read -r f; do gitleaks dir --redact --verbose --no-banner "$f" || status=1; done; exit $status; }
+        """#
 }
 
 hooks {

--- a/hk/Shared.pkl
+++ b/hk/Shared.pkl
@@ -30,6 +30,12 @@ local linters = new Mapping<String, Step> {
 // `git ls-files --cached` は index 上のパスを列挙するため、作業ツリーから削除済み
 // （かつ未ステージ）のファイルも含まれる。存在しないパスを `gitleaks dir` に渡すと
 // エラー終了するため、ループ内で現存チェックしてスキップする。
+// `git ls-files` は core.quotePath（既定 true）により、日本語等の非ASCII文字を含む
+// パスを `"\346..."` のような引用符付き8進エスケープで出力する。改行区切りで
+// そのまま `read` すると引用符付き文字列がそのまま変数に入り、実在チェックが
+// 常に失敗して該当ファイルが黙ってスキップされる。`-z`（NUL区切り、常に非エスケープの
+// 生パスを出力）を使い、`read -d` が使えないPOSIX sh（dash等）でも動くよう
+// `tr '\0' '\n'` で改行区切りへ変換してから読む。
 local gitleaksPreCommit = new Step {
     types = List("text")
     check = "gitleaks git --staged --redact --verbose --no-banner"
@@ -38,7 +44,7 @@ local gitleaksPreCommit = new Step {
 local gitleaksFullScan = new Step {
     types = List("text")
     check = #"""
-        gitleaks git --redact --verbose --no-banner && git ls-files --cached --others --exclude-standard | { status=0; while IFS= read -r f; do [ -e "$f" ] || continue; gitleaks dir --redact --verbose --no-banner "$f" || status=1; done; exit $status; }
+        gitleaks git --redact --verbose --no-banner && git ls-files -z --cached --others --exclude-standard | tr '\0' '\n' | { status=0; while IFS= read -r f; do [ -e "$f" ] || continue; gitleaks dir --redact --verbose --no-banner "$f" || status=1; done; exit $status; }
         """#
 }
 


### PR DESCRIPTION
## 概要

- 共通hkフックの `gitleaks` ステップを `Builtins.gitleaks`（`gitleaks dir {{ files }}`）から、`gitleaks git --staged` を使う独自Stepへ切り替える

## 背景

- `Builtins.gitleaks` は `gitleaks dir --redact --verbose --no-banner {{ files }}` を実行する
- `gitleaks dir` はディレクトリ引数を1つしか受け付けない仕様のため、hkがステージ済みファイルを複数の位置引数として展開すると、意図した「対象ファイルだけのスキャン」にならず、リポジトリ全体（.gitignore対象を含む）を走査してしまう
- 実際に dotclaude リポジトリで2ファイル以上を同時コミットしようとした際、`~/.claude` 配下のセッションログやプラグインキャッシュ（.gitignore済み、無関係）から大量の誤検知が出てpre-commitが失敗する事象を確認した
- `gitleaks git --staged` はpre-commit向けの用途として用意されたモードで、ステージ済み差分だけを対象にするため、この問題が起きない

## 変更内容

- `hk/Shared.pkl` の `gitleaks` ステップを `check = "gitleaks git --staged --redact --verbose --no-banner"` を使う独自Stepに置き換え

## Test plan

- [x] `hk validate`（ローカルでShared.pklをamendsする一時hk.pklを用意して検証）
- [x] クリーンなステージ済みファイル + .gitignore対象の偽シークレットファイルで、gitleaksが.gitignore対象を無視しステージ済みファイルのみをスキャンすることを確認
- [x] ステージ済みファイルに実際の偽シークレットを含めた場合、正しく検出してpre-commitが失敗することを確認（検出能力の劣化がないことを確認）