### PR TITLE
feat: post-mergeでShared.pkl更新時にhkキャッシュを自動クリアする

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -13,6 +13,16 @@ hooks {
                 )
                 check = "scripts/check-workflow-templates.sh"
             }
+            // post-merge/post-checkout フックは、既存クローンに以前の `hk install` で
+            // 作られた git hook shim が無いと発火しない。新しい hook 種別を hk.pkl に
+            // 追加しても、既存クローン側で `hk install` を再実行しない限り shim は
+            // 増えないため、まさにキャッシュを自動クリアしたい既存環境で機能しない。
+            // pre-commit の shim は既存クローンに既に入っているため、ここで
+            // `hk install` を毎回実行して shim 一式を追従させ、次のコミット以降は
+            // post-merge/post-checkout が確実に発火する状態を自己修復する。
+            ["ensure_hk_hooks_installed"] {
+                check = "hk install --mise >/dev/null 2>&1 || true"
+            }
         }
     }
     // hk/Shared.pkl は各管理対象リポジトリの hk.pkl から amends されるが、

--- a/hk.pkl
+++ b/hk.pkl
@@ -29,4 +29,16 @@ hooks {
             }
         }
     }
+    // post-merge だけでは、default branch がどの worktree でも checkout されていない
+    // 状態で local main の ref だけを直接更新する運用（例: git-cleanup.sh の
+    // sync_default_branch が `git update-ref` にフォールバックするケース）を取りこぼす。
+    // git update-ref はフックを経由しないため、その後 `git switch main` 等で checkout
+    // し直した時点の post-checkout で改めて hk/Shared.pkl の差分を確認する。
+    ["post-checkout"] {
+        steps {
+            ["clear_hk_cache"] {
+                check = "[ '{{ is_branch_checkout }}' = 'true' ] && git diff --name-only '{{ prev_head }}' '{{ new_head }}' 2>/dev/null | grep -qx 'hk/Shared.pkl' && hk cache clear || true"
+            }
+        }
+    }
 }

--- a/hk.pkl
+++ b/hk.pkl
@@ -15,4 +15,18 @@ hooks {
             }
         }
     }
+    // hk/Shared.pkl は各管理対象リポジトリの hk.pkl から amends されるが、
+    // hk はリモート import を含む設定を ~/.cache/hk にキャッシュし、時間による失効が無い。
+    // このクローンで hk/Shared.pkl の変更を取り込む git merge（PR マージ後の git pull 等）が
+    // 起きたときにキャッシュを自動でクリアし、Shared.pkl 更新が反映されない事故を防ぐ。
+    // post-merge のステップは glob によるファイルフィルタがマージ差分ではなく作業ツリーの
+    // 変更ファイルを見てしまい常に空集合になるため使えない。check コマンド側で
+    // ORIG_HEAD..HEAD の差分を見て対象ファイルの有無を判定する。
+    ["post-merge"] {
+        steps {
+            ["clear_hk_cache"] {
+                check = "git diff --name-only ORIG_HEAD HEAD 2>/dev/null | grep -qx 'hk/Shared.pkl' && hk cache clear || true"
+            }
+        }
+    }
 }


### PR DESCRIPTION
## 概要

- hk はリモート import を含む hk.pkl 設定を `~/.cache/hk` にキャッシュし、時間による失効が無い。`hk/Shared.pkl`（各管理対象リポジトリの `hk.pkl` が amends する共通フック設定）を更新しても、このクローンで既にキャッシュが温まっていると、更新が反映されない。
- `post-merge` フックを追加し、`hk/Shared.pkl` を含む `git merge`（fast-forward の `git pull` を含む）で `hk cache clear` を自動実行する。
- `post-merge` だけでは、default branch がどの worktree でも checkout されていない状態で local main の ref だけを直接更新する運用（`~/.claude/skills/git-cleanup` の `sync_default_branch` が `git update-ref` にフォールバックするケース）を取りこぼす。`git update-ref` はフックを経由しないため、その後 `git switch main` 等で checkout し直した時点の `post-checkout` で改めて差分を確認するステップも追加した。
- 両ステップとも `glob` によるファイルフィルタはマージ/チェックアウト差分ではなく作業ツリーの変更ファイルを見てしまい常に空集合になるため使えず、`check` コマンド側で該当区間の `git diff` を判定する方式にした。
- レビュー指摘（P1）: 既存クローンには過去の `hk install` で `pre-commit`/`pre-push` の git hook shim しか無く、`post-merge`/`post-checkout` は対応する shim が無いと発火しない。新しい hook 種別を hk.pkl に追加しても、既存クローン側で `hk install` を再実行しない限り shim は増えないため、まさにキャッシュを自動クリアしたい既存環境で機能が恒久的に無効になっていた。`pre-commit` の shim は既存クローンに既に入っているため、そこで `hk install --mise` を毎回実行して shim 一式を追従させる `ensure_hk_hooks_installed` ステップを追加し、次のコミット以降は post-merge/post-checkout が確実に発火する状態へ自己修復するようにした。

## 検証

- ローカルの使い捨てブランチで以下を確認した。
  - `post-merge`: `--no-ff` マージ・fast-forward マージの両方で、実際の `git merge` により自動発火してキャッシュがクリアされる
  - `post-checkout`: `git update-ref` によるサイレントな ref 更新後は発火しない（想定通り）→ その後 `git switch` した時点で発火し、キャッシュがクリアされる
  - `hk/Shared.pkl` を含まない変更では不要にキャッシュをクリアしない（`grep -qx` によるファイル名の完全一致判定）
  - `post-merge`/`post-checkout` の shim を削除して「既存クローン」状態を再現し、`pre-commit` をトリガーするコミットを1回実行するだけで `hk install --mise` が走り、shim が復元されることを確認した

## Test plan

- [x] `hk validate` が通る
- [x] `post-merge` / `post-checkout` それぞれの実発火とキャッシュクリアを確認済み
- [x] shim 欠落状態からの `pre-commit` 経由の自己修復を確認済み
- [ ] レビュー後、実際の運用（`git pull` や `~/.claude/skills/git-cleanup` の `gc` コマンド経由）で継続動作を確認